### PR TITLE
feat: Share & Save formations as images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,10 @@
         "expo-image-picker": "~16.1.4",
         "expo-linear-gradient": "~14.1.5",
         "expo-linking": "~7.1.7",
+        "expo-media-library": "^55.0.9",
         "expo-router": "~5.1.11",
         "expo-screen-orientation": "~8.1.7",
+        "expo-sharing": "^55.0.11",
         "expo-splash-screen": "~0.30.10",
         "expo-status-bar": "~2.2.3",
         "expo-system-ui": "~5.0.11",
@@ -32,6 +34,7 @@
         "react-native-screens": "~4.11.1",
         "react-native-svg": "15.11.2",
         "react-native-vector-icons": "^10.3.0",
+        "react-native-view-shot": "^4.0.3",
         "react-native-web": "^0.20.0"
       },
       "devDependencies": {
@@ -3785,6 +3788,15 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -4545,6 +4557,15 @@
       "license": "MIT",
       "dependencies": {
         "hyphenate-style-name": "^1.0.3"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-select": {
@@ -5337,6 +5358,16 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-media-library": {
+      "version": "55.0.9",
+      "resolved": "https://registry.npmjs.org/expo-media-library/-/expo-media-library-55.0.9.tgz",
+      "integrity": "sha512-E12e4gjQEZNdAa7MHDLOAiOMQmhmOGHFMMU5DpiK6I01hPXyRcaxgAQQLpibIXNP4O5LjGi2psa3NBacjyjxkw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-modules-autolinking": {
       "version": "2.1.15",
       "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-2.1.15.tgz",
@@ -5430,6 +5461,160 @@
       "peerDependencies": {
         "expo": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-sharing": {
+      "version": "55.0.11",
+      "resolved": "https://registry.npmjs.org/expo-sharing/-/expo-sharing-55.0.11.tgz",
+      "integrity": "sha512-YlVez832W0sYR2KJY4Dr8ON9aC+Wp8a/r40eQyhoHT9Tetkr2KBM7tWLT0CGKRuTTnrqJL1C51UacLkHJ9zmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config-plugins": "^55.0.6",
+        "@expo/config-types": "^55.0.5",
+        "@expo/plist": "^0.5.2"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-sharing/node_modules/@expo/config-plugins": {
+      "version": "55.0.6",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-55.0.6.tgz",
+      "integrity": "sha512-cIox6FjZlFaaX40rbQ3DvP9e87S5X85H9uw+BAxJE5timkMhuByy3GAlOsj1h96EyzSiol7Q6YIGgY1Jiz4M+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config-types": "^55.0.5",
+        "@expo/json-file": "~10.0.12",
+        "@expo/plist": "^0.5.2",
+        "@expo/sdk-runtime-versions": "^1.0.0",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.5",
+        "getenv": "^2.0.0",
+        "glob": "^13.0.0",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.5.4",
+        "slugify": "^1.6.6",
+        "xcode": "^3.0.1",
+        "xml2js": "0.6.0"
+      }
+    },
+    "node_modules/expo-sharing/node_modules/@expo/config-types": {
+      "version": "55.0.5",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-55.0.5.tgz",
+      "integrity": "sha512-sCmSUZG4mZ/ySXvfyyBdhjivz8Q539X1NondwDdYG7s3SBsk+wsgPJzYsqgAG/P9+l0xWjUD2F+kQ1cAJ6NNLg==",
+      "license": "MIT"
+    },
+    "node_modules/expo-sharing/node_modules/@expo/json-file": {
+      "version": "10.0.12",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.12.tgz",
+      "integrity": "sha512-inbDycp1rMAelAofg7h/mMzIe+Owx6F7pur3XdQ3EPTy00tme+4P6FWgHKUcjN8dBSrnbRNpSyh5/shzHyVCyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.20.0",
+        "json5": "^2.2.3"
+      }
+    },
+    "node_modules/expo-sharing/node_modules/@expo/plist": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.5.2.tgz",
+      "integrity": "sha512-o4xdVdBpe4aTl3sPMZ2u3fJH4iG1I768EIRk1xRZP+GaFI93MaR3JvoFibYqxeTmLQ1p1kNEVqylfUjezxx45g==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.8",
+        "base64-js": "^1.5.1",
+        "xmlbuilder": "^15.1.1"
+      }
+    },
+    "node_modules/expo-sharing/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/expo-sharing/node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/expo-sharing/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/expo-sharing/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/expo-sharing/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/expo-sharing/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/expo-sharing/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/expo-splash-screen": {
@@ -5926,6 +6111,19 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -8376,10 +8574,10 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "license": "ISC",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -9644,6 +9842,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/react-native-view-shot": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/react-native-view-shot/-/react-native-view-shot-4.0.3.tgz",
+      "integrity": "sha512-USNjYmED7C0me02c1DxKA0074Hw+y/nxo+xJKlffMvfUWWzL5ELh/TJA/pTnVqFurIrzthZDPtDM7aBFJuhrHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "html2canvas": "^1.4.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-web": {
       "version": "0.20.0",
       "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.20.0.tgz",
@@ -10866,6 +11077,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -11168,6 +11388,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,10 @@
     "expo-image-picker": "~16.1.4",
     "expo-linear-gradient": "~14.1.5",
     "expo-linking": "~7.1.7",
+    "expo-media-library": "^55.0.9",
     "expo-router": "~5.1.11",
     "expo-screen-orientation": "~8.1.7",
+    "expo-sharing": "^55.0.11",
     "expo-splash-screen": "~0.30.10",
     "expo-status-bar": "~2.2.3",
     "expo-system-ui": "~5.0.11",
@@ -40,6 +42,7 @@
     "react-native-screens": "~4.11.1",
     "react-native-svg": "15.11.2",
     "react-native-vector-icons": "^10.3.0",
+    "react-native-view-shot": "^4.0.3",
     "react-native-web": "^0.20.0"
   },
   "devDependencies": {

--- a/social/content-plan.md
+++ b/social/content-plan.md
@@ -1,0 +1,22 @@
+# CourtSim X Content Plan
+
+## Content Pillars
+1. **App Features** — showcase what CourtSim does (30%)
+2. **Badminton Tips** — positioning, rotation, tactics (40%)
+3. **Engagement** — polls, questions, memes (20%)
+4. **Updates** — new features, releases (10%)
+
+## Posting Schedule
+- 3-4 tweets per week
+- Best times: 7-9am, 12-1pm, 6-8pm (mix of timezones for global reach)
+- Avoid posting multiple times in a day early on
+
+## Hashtags (rotate, use 2-3 per tweet)
+#badminton #badmintonlife #shuttlecock #badmintonplayer #badmintoncourt
+#badmintontraining #badmintonlovers #doubles #badmintontips #courtcraft
+#badmintoncoaching #racquetsports
+
+## Tone
+- Casual, knowledgeable, slightly playful
+- Like a doubles partner who knows their stuff
+- Not salesy — provide value first

--- a/social/drafts/batch-1.md
+++ b/social/drafts/batch-1.md
@@ -1,0 +1,82 @@
+# Batch 1 — Draft Tweets
+
+## Tweet 1 (Intro/Launch)
+🏸 Meet CourtSim — a free badminton court simulator
+
+Drag players around the court, plan formations, practice rotations, and share tactics with your doubles partner.
+
+Available now on Google Play 👇
+https://play.google.com/store/apps/details?id=com.haritabhgupta.badmintoncourtsimulator
+
+#badminton #badmintondoubles #badmintontraining
+
+---
+
+## Tweet 2 (Doubles Tip)
+Most doubles points are lost because of bad rotation, not bad shots.
+
+Front-and-back on attack. Side-by-side on defense. Sounds simple but how often does your partner actually know the plan?
+
+Plan it out first → CourtSim (free on Play Store)
+
+#badminton #doubles #badmintontips
+
+---
+
+## Tweet 3 (Engagement — Poll)
+Doubles players, honest question:
+
+Do you and your partner actually discuss court positioning before a match?
+
+🔥 Every time
+😅 Sometimes
+💀 We just wing it
+🤔 Wait, you're supposed to?
+
+#badminton #badmintondoubles
+
+---
+
+## Tweet 4 (Feature Highlight)
+Tired of explaining formations on a napkin?
+
+CourtSim lets you:
+• Drag players to any position
+• Toggle between singles & doubles
+• Track movement trails
+• Customize player icons with photos
+
+Free. No ads. No catch.
+
+#badminton #badmintoncoaching
+
+---
+
+## Tweet 5 (Tip — Positioning)
+The T-position in doubles isn't just for serving.
+
+After every return, both players should reset relative to the T. Most club players chase the shuttle and forget to reposition.
+
+Drill it with CourtSim 🏸
+
+#badminton #badmintontips #courtcraft
+
+---
+
+## Tweet 6 (Engagement — Question)
+What's the most frustrating thing your doubles partner does on court?
+
+(Mine is standing in the middle when I'm trying to smash 😤)
+
+#badminton #badmintondoubles #badmintonlife
+
+---
+
+## Tweet 7 (Feature — Trails)
+New favourite feature: movement trails 👣
+
+See exactly where each player moved during a rally. Perfect for coaches breaking down positioning mistakes.
+
+Try it → CourtSim (free on Play Store)
+
+#badminton #badmintoncoaching #badmintontraining

--- a/social/drafts/reddit-post.md
+++ b/social/drafts/reddit-post.md
@@ -1,0 +1,37 @@
+# Reddit Post — r/badminton
+
+## Title
+I built a free badminton court simulator for planning doubles formations
+
+## Body
+
+Hey everyone,
+
+I play doubles regularly and got tired of trying to explain court rotations to my partner using hand gestures and scribbles. So I built an app for it.
+
+**CourtSim** is a free, no-ads badminton court simulator where you can:
+
+- Drag and drop players on a realistic court
+- Switch between singles and doubles
+- See movement trails to visualize rotations
+- Customize players with photos, colors, and labels
+- Undo/redo to compare different formations
+
+It's designed to be dead simple — open the app, drag players around, done. No account, no signup, no nonsense.
+
+I mainly use it before matches to quickly show my partner "you go here after the serve, I cover there" instead of trying to explain it verbally.
+
+It's free on Google Play: [link]
+
+Would love feedback from the community. What features would make this actually useful for your training? Thinking about adding save/export for formations and maybe preset drill patterns.
+
+Cheers 🏸
+
+---
+
+## Notes
+- Post on a weekday morning (Tue-Thu) for best visibility
+- Don't crosspost immediately — wait a few days
+- Reply to every comment genuinely
+- If it gains traction, follow up with a "you asked for X, I built it" post later
+- Check r/badminton rules before posting — some subs restrict self-promotion

--- a/social/play-store-listing.md
+++ b/social/play-store-listing.md
@@ -1,0 +1,57 @@
+# Play Store Listing — Optimized
+
+## App Title (30 chars max)
+CourtSim: Badminton Planner
+
+## Short Description (80 chars max)
+Plan badminton formations, drill rotations & share court tactics with partners.
+
+## Full Description (4000 chars max)
+
+CourtSim is a free, interactive badminton court simulator designed for players, coaches, and clubs who want to improve their court positioning and doubles strategy.
+
+🏸 DRAG & DROP COURT PLANNING
+Move players and the shuttle anywhere on a realistic badminton court. Plan your formations before you step on court — no more explaining tactics on a napkin.
+
+👥 SINGLES & DOUBLES MODE
+Switch between singles and doubles with one tap. Default is doubles because that's where positioning matters most.
+
+🔄 UNDO/REDO & POSITION HISTORY
+Made a mistake? Go back. Want to compare two formations? Step through your position history and see what works best.
+
+👣 MOVEMENT TRAILS
+Toggle visual trails to see exactly where players and the shuttle moved. Perfect for coaches breaking down rally patterns and identifying positioning mistakes.
+
+🎨 FULL PLAYER CUSTOMIZATION
+Make it yours:
+• Choose from built-in icons or add custom text labels
+• Upload player photos for easy identification
+• Adjust marker colors per team (red/blue default)
+• Resize markers from 20-80px
+
+⚙️ SETTINGS PANEL
+View and manage all player customizations in one place. Organized by team with visual previews. Reset everything with one tap.
+
+📱 DESIGNED FOR MOBILE
+Smooth 60fps animations, responsive touch controls, and a clean Material Design interface. Works on any Android device.
+
+FREE FOREVER
+No ads. No in-app purchases. No account required. Just open and play.
+
+PERFECT FOR:
+• Doubles partners planning rotation strategy
+• Coaches teaching court positioning
+• Clubs running training sessions
+• Players studying formation patterns
+• Anyone who wants to get better at badminton
+
+Download CourtSim and start planning your next winning formation. 🏸
+
+## Keywords/Tags
+badminton, court simulator, badminton coach, doubles strategy, badminton training, court positioning, badminton formation, shuttle, racquet sports, badminton tactics, badminton drill, doubles rotation
+
+## Category
+Sports
+
+## Content Rating
+Everyone

--- a/social/x-monitor-accounts.md
+++ b/social/x-monitor-accounts.md
@@ -1,0 +1,27 @@
+# X Accounts to Monitor for Reply Opportunities
+
+## Priority (check daily)
+- BWFWorldTour — tournament updates, results
+- BadmintonTalk — community discussions
+- ViktorAxelsen — world #1, massive reach
+- PVSindhu1 — Olympic medalist
+
+## Secondary (check every few days)
+- YonexBadminton — equipment, sponsorships
+- BadmintonEngland — community events
+- BadmintonIreland — local relevance (Dublin-based)
+- LiNingBadminton — equipment
+
+## What to look for
+- Posts about doubles strategy/positioning
+- Training tips or coaching content
+- "What app do you use for..." questions
+- Tournament discussions where tactics come up
+- Memes about doubles partners
+- Any post with high engagement about court positioning
+
+## Reply style
+- Be genuinely helpful, not promotional
+- Add value to the conversation
+- Only mention the app if directly relevant
+- Keep it casual and knowledgeable


### PR DESCRIPTION
## What
Add ability to share court formations as images and save them to gallery.

## How
- `react-native-view-shot` captures the court view (players, shuttle, trails) as a PNG
- `expo-sharing` opens the native share sheet (WhatsApp, Instagram, etc.)
- `expo-media-library` saves to device gallery as fallback

## UI
New "Share" button group in the bottom bar with:
- Share icon (opens share sheet)
- Save icon (saves to gallery)

## Testing needed
- Share to WhatsApp/Instagram/etc
- Save to gallery
- Verify captured image includes trails and customizations