### PR TITLE
build(android): add Play Billing permission, bump version to 2.1.0

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -98,8 +98,8 @@ android {
         applicationId 'com.haritabhgupta.badmintoncourtsimulator'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 9
-        versionName "2.0.1"
+        versionCode 10
+        versionName "2.1.0"
     }
     signingConfigs {
         debug {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
+  <uses-permission android:name="com.android.vending.BILLING"/>
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
   <uses-permission android:name="android.permission.RECORD_AUDIO"/>


### PR DESCRIPTION
## Summary

Bare-minimum change to unblock subscription product creation in Play Console, which requires a build carrying the billing permission on any track:

- `AndroidManifest.xml`: add `com.android.vending.BILLING` permission
- `build.gradle`: `versionCode` 9 → 10, `versionName` 2.0.1 → 2.1.0 (Play requires a higher versionCode than the released build)

No feature code. The Drill Vault feature ships in a separate PR after real billing (RevenueCat) is integrated.

## After merging

The release workflow triggers on push to `main` — download the `app-release` AAB artifact from that run, upload it to **Internal testing → Create new release → Save as draft**, and the Subscriptions page in Play Console unblocks.

## Test plan

- Local `bundleRelease` build succeeds; merged manifest verified to contain the billing permission.
