### PR TITLE
Fix keyboard-corrupted drill saves and dead link imports; cap drills at 5; static mode pill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,59 @@
+# AGENTS.md
+
+Badminton court simulator — an Expo (React Native) app using expo-router.
+
+## Commands
+
+- `npm run android` — run on Android
+- `npm run web` — run in browser
+- `npm run lint` — lint
+- `npx jest` — run tests once (`npm test` runs jest in `--watchAll` mode; don't use it in agents/CI)
+
+## Testing
+
+**All testing must happen on an Android Virtual Device (emulator).** Jest alone is not sufficient verification — before declaring a change working, run the app on an AVD and exercise the affected flow. Do not verify only on web; Android is the target platform.
+
+Working recipe (requires JDK 17 and the Android SDK; export `JAVA_HOME` and `ANDROID_HOME` for your machine):
+
+```bash
+export PATH=$PATH:$ANDROID_HOME/platform-tools
+$ANDROID_HOME/emulator/emulator -list-avds            # pick any AVD; create one via Android Studio or avdmanager
+$ANDROID_HOME/emulator/emulator -avd <avd> -no-window -no-audio -gpu swiftshader_indirect &
+adb wait-for-device
+cd android && ./gradlew assembleRelease --no-daemon && cd ..
+adb install -r android/app/build/outputs/apk/release/app-release.apk
+adb shell am start -n com.haritabhgupta.badmintoncourtsimulator/.MainActivity
+adb exec-out screencap -p > screen.png                # inspect UI state
+adb shell input tap X Y / input swipe X1 Y1 X2 Y2 600 # drive it (coords in px)
+```
+
+Critical user flows to exercise: drag a marker (step count increments), undo/redo/reset, singles/doubles switch (Customize panel), save/load/delete a drill, share link, deep-link import:
+
+```bash
+adb shell am start -a android.intent.action.VIEW \
+  -d "https://badmlabs.github.io/i.html?d=<payload>" com.haritabhgupta.badmintoncourtsimulator
+```
+
+Ground truth for saved drills: use a `google_apis` (non-Play) emulator image so `adb root` works; saved drills live in sqlite at `/data/data/com.haritabhgupta.badmintoncourtsimulator/databases/RKStorage`, key `badminton-step-sets`. If you push that DB back: force-stop the app first, keep the value column TEXT (sqlite's `readfile()` writes a BLOB, which the app reads as empty), then `chown` to the app uid and `restorecon -RF` the databases dir — otherwise the app silently recreates empty storage.
+
+## Layout
+
+- `app/` — expo-router screens
+- `components/` — shared UI
+- `context/` — app state (React context)
+- `utils/`, `types/`, `constants/`, `hooks/` — what they say
+
+## Conventions
+
+- Commit messages: Conventional Commits, `type(scope): description`. No AI attribution/co-author lines.
+- TypeScript throughout.
+
+## Gotchas
+
+- Release builds sign with the checked-in debug keystore when no `keystore.properties` exists, so `assembleRelease` always yields an installable test APK at `android/app/build/outputs/apk/release/app-release.apk`.
+- Share links use the v3 compact format (see `utils/stepSharing.ts`): `https://badmlabs.github.io/i.html?d=<base64url>`, 12-bit coords over [-0.5, 1.5].
+- `adb shell input text` needs `%s` for spaces; dialogs shift up when the keyboard opens, so re-screenshot before tapping their buttons.
+- Marker positions in state are view **top-left in dp**, not centers (`utils/courtPositions.ts`); drill save/load normalizes them against the root view size.
+- Android soft input mode is deliberately `adjustPan` (AndroidManifest.xml + `app.json`). Do not switch it back to `adjustResize`: the keyboard would shrink the root view and drill saves made from the name dialog would normalize y against the shrunken height (stored y > 1, drills reload shifted off-court).
+- Share-link / clipboard imports always go through a confirm dialog, and the apply is routed through the module-level `liveApplyImport` ref in `components/BadmintonCourt.tsx` — a share link remounts the component (via `+not-found`), so per-instance closures go stale. Keep new import paths behind that ref.
+- Saved drills are capped at 5 (`STEP_SET_LIMIT` in `hooks/useStepSets.ts`); the guard lives in `saveStepSet`, which all save/import paths route through.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
     <meta-data android:name="expo.modules.updates.ENABLED" android:value="false"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH" android:value="ALWAYS"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS" android:value="0"/>
-    <activity android:name=".MainActivity" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|screenLayout|uiMode" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:theme="@style/Theme.App.SplashScreen" android:exported="true" android:screenOrientation="portrait">
+    <activity android:name=".MainActivity" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|screenLayout|uiMode" android:launchMode="singleTask" android:windowSoftInputMode="adjustPan" android:theme="@style/Theme.App.SplashScreen" android:exported="true" android:screenOrientation="portrait">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>
         <category android:name="android.intent.category.LAUNCHER"/>

--- a/app.json
+++ b/app.json
@@ -16,6 +16,7 @@
       "**/*"
     ],
     "android": {
+      "softwareKeyboardLayoutMode": "pan",
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"

--- a/components/BadmintonCourt.tsx
+++ b/components/BadmintonCourt.tsx
@@ -286,19 +286,14 @@ export default function BadmintonCourt() {
         onIconChange={(icon) => updateMarkerCustomization('Shuttle', { icon })}
       />
 
-      {/* Floating header: mode pill + customize button */}
+      {/* Floating header: mode status pill + customize button */}
       <View style={[styles.header, { marginTop: headerTop }]} pointerEvents="box-none">
-        <Pressable
-          onPress={() => toggleGameMode(!isDoubles)}
-          hitSlop={8}
-          style={({ pressed }) => [styles.modePill, pressed && styles.glassPressed]}
-        >
+        <View style={styles.modePill}>
           <MaterialCommunityIcons name="badminton" size={18} color={palette.textPrimary} />
           <Text style={styles.modePillLabel}>
             {isDoubles ? 'Doubles' : 'Singles'} · Step {stepCount}
           </Text>
-          <MaterialCommunityIcons name="chevron-down" size={16} color={palette.textSecondary} />
-        </Pressable>
+        </View>
         <Pressable
           onPress={() => setIsMenuVisible(true)}
           hitSlop={8}
@@ -338,6 +333,8 @@ export default function BadmintonCourt() {
       <SettingsPanel
         isVisible={isMenuVisible}
         onClose={() => setIsMenuVisible(false)}
+        isDoubles={isDoubles}
+        onGameModeChange={toggleGameMode}
       />
 
       <StepSetsPanel

--- a/components/BadmintonCourt.tsx
+++ b/components/BadmintonCourt.tsx
@@ -26,6 +26,14 @@ const LINES_GAP = 16;
 // re-import a URL that was already handled in this app session.
 const consumedShareUrls = new Set<string>();
 
+// A share link remounts this component (via +not-found) right after the URL
+// event fires, so the import dialog — which survives in the root-level
+// AppAlertHost — must apply through whichever instance is mounted when the
+// user answers, not through the closure that showed it.
+const liveApplyImport: {
+  current: ((stepSet: StepSet, replaceId?: string) => void) | null;
+} = { current: null };
+
 export default function BadmintonCourt() {
   const insets = useSafeAreaInsets();
 
@@ -129,27 +137,28 @@ export default function BadmintonCourt() {
     appAlert('Imported', `"${saved.name}" has been imported and loaded.`);
   }, [importStepSet, loadNormalizedSteps, replaceStepSet]);
 
+  useEffect(() => {
+    liveApplyImport.current = applyImport;
+  }, [applyImport]);
+
   const handleImportStepSet = useCallback(async (stepSet: StepSet) => {
     const existing = stepSets.find((item) => item.name === stepSet.name);
 
-    if (existing) {
-      appAlert(
-        'Drill already exists',
-        `A drill named "${stepSet.name}" is already saved. Replace it?`,
-        [
-          { text: 'Cancel', style: 'cancel' },
-          {
-            text: 'Replace',
-            style: 'destructive',
-            onPress: () => applyImport(stepSet, existing.id),
-          },
-        ]
-      );
-      return;
-    }
-
-    await applyImport(stepSet);
-  }, [applyImport, stepSets]);
+    appAlert(
+      existing ? 'Drill already exists' : 'Import drill',
+      existing
+        ? `A drill named "${stepSet.name}" is already saved. Replace it?`
+        : `Import "${stepSet.name}" and load it onto the court?`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: existing ? 'Replace' : 'Import',
+          style: existing ? 'destructive' : 'default',
+          onPress: () => liveApplyImport.current?.(stepSet, existing?.id),
+        },
+      ]
+    );
+  }, [stepSets]);
 
   const handleImportStepSetRef = useRef(handleImportStepSet);
   useEffect(() => {

--- a/components/BadmintonCourt.tsx
+++ b/components/BadmintonCourt.tsx
@@ -133,6 +133,7 @@ export default function BadmintonCourt() {
     const saved = replaceId
       ? await replaceStepSet(replaceId, stepSet)
       : await importStepSet(stepSet);
+    if (!saved) return; // drill limit reached; the hook already alerted
     loadNormalizedSteps(saved.steps, saved.isDoubles);
     appAlert('Imported', `"${saved.name}" has been imported and loaded.`);
   }, [importStepSet, loadNormalizedSteps, replaceStepSet]);
@@ -193,7 +194,7 @@ export default function BadmintonCourt() {
       width: screenWidth,
       height: screenHeight,
     });
-    await saveStepSet(stepSet);
+    return (await saveStepSet(stepSet)) !== null;
   }, [getStepsSnapshot, isDoubles, saveStepSet, screenHeight, screenWidth]);
 
   const handleLoadStepSet = useCallback((stepSet: StepSet) => {

--- a/components/SettingsPanel.tsx
+++ b/components/SettingsPanel.tsx
@@ -240,10 +240,17 @@ function MarkerItem({ markerId, title, customizations, updateMarkerCustomization
 interface SettingsPanelProps {
   isVisible: boolean;
   onClose: () => void;
+  isDoubles: boolean;
+  onGameModeChange: (isDoubles: boolean) => void;
 }
 
-export function SettingsPanel({ isVisible, onClose }: SettingsPanelProps) {
+export function SettingsPanel({ isVisible, onClose, isDoubles, onGameModeChange }: SettingsPanelProps) {
   const { customizations, updateMarkerCustomization, resetCustomizations } = useMarkerCustomization();
+
+  // Switching mode reseeds the court, so ignore taps on the already-active option.
+  const selectMode = (doubles: boolean) => {
+    if (doubles !== isDoubles) onGameModeChange(doubles);
+  };
 
   const confirmReset = () => {
     appAlert(
@@ -274,7 +281,7 @@ export function SettingsPanel({ isVisible, onClose }: SettingsPanelProps) {
           <View style={styles.header}>
             <View>
               <Text style={styles.headerTitle}>Customize</Text>
-              <Text style={styles.headerSubtitle}>Marker colors, icons and sizes</Text>
+              <Text style={styles.headerSubtitle}>Game mode, marker colors, icons and sizes</Text>
             </View>
             <TouchableOpacity onPress={onClose} hitSlop={8} style={styles.closeButton}>
               <MaterialCommunityIcons name="close" size={18} color={palette.textPrimary} />
@@ -286,6 +293,36 @@ export function SettingsPanel({ isVisible, onClose }: SettingsPanelProps) {
             contentContainerStyle={styles.scrollContent}
             showsVerticalScrollIndicator={false}
           >
+            <Text style={styles.sectionLabel}>Game mode</Text>
+            <View style={styles.modeCard}>
+              <TouchableOpacity
+                style={[styles.modeOption, !isDoubles && styles.modeOptionActive]}
+                onPress={() => selectMode(false)}
+              >
+                <MaterialCommunityIcons
+                  name="account"
+                  size={15}
+                  color={!isDoubles ? palette.onAccent : palette.textSecondary}
+                />
+                <Text style={[styles.modeOptionText, !isDoubles && styles.modeOptionTextActive]}>
+                  Singles
+                </Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[styles.modeOption, isDoubles && styles.modeOptionActive]}
+                onPress={() => selectMode(true)}
+              >
+                <MaterialCommunityIcons
+                  name="account-multiple"
+                  size={15}
+                  color={isDoubles ? palette.onAccent : palette.textSecondary}
+                />
+                <Text style={[styles.modeOptionText, isDoubles && styles.modeOptionTextActive]}>
+                  Doubles
+                </Text>
+              </TouchableOpacity>
+            </View>
+
             <Text style={styles.sectionLabel}>Team 1</Text>
             <MarkerItem
               markerId="P1"
@@ -411,6 +448,37 @@ const styles = StyleSheet.create({
     color: palette.textMuted,
     marginTop: spacing.md,
     marginBottom: 7,
+  },
+  modeCard: {
+    flexDirection: 'row',
+    gap: 5,
+    backgroundColor: palette.card,
+    borderWidth: 1,
+    borderColor: palette.cardBorder,
+    borderRadius: radii.md,
+    padding: 5,
+    marginBottom: 6,
+  },
+  modeOption: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    height: 38,
+    borderRadius: radii.sm,
+  },
+  modeOptionActive: {
+    backgroundColor: palette.accent,
+  },
+  modeOptionText: {
+    ...sora('600'),
+    fontSize: 13,
+    color: palette.textSecondary,
+  },
+  modeOptionTextActive: {
+    ...sora('700'),
+    color: palette.onAccent,
   },
   rowCard: {
     flexDirection: 'row',

--- a/components/StepSetsPanel.tsx
+++ b/components/StepSetsPanel.tsx
@@ -13,7 +13,7 @@ interface StepSetsPanelProps {
   onClose: () => void;
   stepSets: StepSet[];
   currentStepCount: number;
-  onSave: (name: string) => Promise<void>;
+  onSave: (name: string) => Promise<boolean>;
   onLoad: (stepSet: StepSet) => void;
   onDelete: (id: string) => Promise<void>;
   onImport: (stepSet: StepSet) => Promise<void>;
@@ -67,10 +67,12 @@ export function StepSetsPanel({
 
     setIsSaving(true);
     try {
-      await onSave(trimmedName);
-      setStepSetName('');
+      const saved = await onSave(trimmedName);
       setSaveDialogVisible(false);
-      appAlert('Saved', `"${trimmedName}" has been saved.`);
+      if (saved) {
+        setStepSetName('');
+        appAlert('Saved', `"${trimmedName}" has been saved.`);
+      }
     } catch (error) {
       appAlert('Save failed', 'Could not save this step set.');
       console.error(error);

--- a/hooks/useStepSets.ts
+++ b/hooks/useStepSets.ts
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useState } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { StepSet } from '../types/drill';
+import { appAlert } from '../utils/appAlert';
 
 const STORAGE_KEY = 'badminton-step-sets';
+const STEP_SET_LIMIT = 5;
 
 export function useStepSets() {
   const [stepSets, setStepSets] = useState<StepSet[]>([]);
@@ -41,17 +43,27 @@ export function useStepSets() {
     });
   };
 
-  // Functional updates keep these callbacks stable across renders, so
-  // consumers can safely list them in effect dependencies.
+  // saveStepSet gates on the current list for the cap, so unlike the others
+  // it changes identity when the list does; callers already tolerate that.
+  // Returns null (after alerting) when the limit is hit.
   const saveStepSet = useCallback(async (stepSet: StepSet) => {
+    const isUpdate = stepSets.some((existing) => existing.id === stepSet.id);
+    if (!isUpdate && stepSets.length >= STEP_SET_LIMIT) {
+      appAlert(
+        'Drill limit reached',
+        `Up to ${STEP_SET_LIMIT} drills can be saved. Delete one to make room.`
+      );
+      return null;
+    }
     setStepSets((prev) => {
       const next = [stepSet, ...prev.filter((existing) => existing.id !== stepSet.id)];
       writeToStorage(next);
       return next;
     });
     return stepSet;
-  }, []);
+  }, [stepSets]);
 
+  // Functional updates keep the remaining callbacks stable across renders.
   const deleteStepSet = useCallback(async (id: string) => {
     setStepSets((prev) => {
       const next = prev.filter((stepSet) => stepSet.id !== id);


### PR DESCRIPTION
## Fixes

**Drill saves corrupted while the keyboard is open** — `adjustResize` shrank the root view under the soft keyboard, so saves from the name dialog normalized y against ~578dp instead of the full ~914dp window: stored `y > 1`, and every reload shifted markers ~58% down-court (bottom players off-screen). Switched the activity to `adjustPan` (manifest + app.json). No TextInput lives in the activity window — both are in Modals with their own windows — so nothing changes visually; the court layout just stays stable.

**Share-link imports never reached the board** — the link's `+not-found` redirect remounts `BadmintonCourt` right after the URL event, so the import applied through a dead instance: persisted, but the board stayed on defaults despite the "imported and loaded" alert. Imports now always confirm via a dialog (hosted in the root-level `AppAlertHost`, which survives the remount) and apply through a module-level ref pointing at the live instance. Behavior note: clipboard/link imports of new names now ask before importing instead of importing silently.

## Features

- **Cap saved drills at 5** — one guard in `useStepSets.saveStepSet` (the choke point `importStepSet` also routes through); at the cap it alerts "Drill limit reached" and blocks. Replacing an existing drill stays allowed.
- **Mode pill is now a status chip** — no chevron, non-interactive (an accidental tap used to toggle mode and wipe the board). Singles/Doubles moved into the Customize panel as a themed segmented control; re-selecting the active mode is a no-op.

## Verification

All flows exercised on an Android emulator (API 35) against the release APK: keyboard-open save → stored normalized y ≤ 1 → reload pixel-identical (trails intact); deep-link import warm and cold → confirm → drill loads with full undo/redo history; 6th save and 6th link-import blocked with the limit alert; replace-at-cap allowed; re-tapping the active mode leaves the board untouched. AsyncStorage values inspected directly for the normalization checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)