### PR TITLE
fix(release): bump app.json to 2.1.0 / versionCode 10 (prebuild overrides build.gradle)

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Badminton Court Simulator",
     "slug": "badminton-court-simulator",
-    "version": "2.0.1",
+    "version": "2.1.0",
     "scheme": "badminton-court-simulator",
     "orientation": "portrait",
     "icon": "./assets/logo.png",
@@ -22,8 +22,8 @@
         "backgroundColor": "#ffffff"
       },
       "package": "com.haritabhgupta.badmintoncourtsimulator",
-      "versionCode": 9,
-      "permissions": [],
+      "versionCode": 10,
+      "permissions": ["com.android.vending.BILLING"],
       "intentFilters": [
         {
           "action": "VIEW",


### PR DESCRIPTION
## Why the v2.1.0 deploy failed

`Google Api Error: Version code 9 has already been used.`

The CI workflow runs `npx expo prebuild` before Gradle, and prebuild stamps `app.json`'s `android.versionCode` over `build.gradle`. PR #8 bumped only `build.gradle`, so the tag build was silently reverted to versionCode 9 and Play rejected it.

## Change (app.json only)

- `version`: 2.0.1 → **2.1.0**
- `android.versionCode`: 9 → **10**
- `android.permissions`: declare `com.android.vending.BILLING` so prebuild owns the permission (belt-and-braces with the manifest line from #8)

## After merging

Delete the stale `v2.1.0` tag/release and re-create it on the new `main` — the tag run will then deploy versionCode 10 to the internal track:

```
gh release delete v2.1.0 -R badmlabs/badminton-court-simulator --cleanup-tag -y   # if a release exists; otherwise just delete the tag
gh release create v2.1.0 -R badmlabs/badminton-court-simulator --target main -t v2.1.0 -n "Billing permission, version 2.1.0"
```
