### PR TITLE
build(android): add Play Billing Library 7.1.1 (Play rejects bare BILLING permission)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -171,6 +171,11 @@ dependencies {
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
 
+    // Play requires Billing Library >= 6.0.1 whenever the BILLING permission is
+    // declared; without it the artifact is rejected as a deprecated AIDL
+    // integration. Superseded by the RevenueCat SDK's own billing client later.
+    implementation("com.android.billingclient:billing:7.1.1")
+
     def isGifEnabled = (findProperty('expo.gif.enabled') ?: "") == "true";
     def isWebpEnabled = (findProperty('expo.webp.enabled') ?: "") == "true";
     def isWebpAnimatedEnabled = (findProperty('expo.webp.animated') ?: "") == "true";


### PR DESCRIPTION
## Why the second v2.1.0 deploy failed

`Google Api Error: Artifact with version code 10 uses Play Billing Library version AIDL and must update to at least version 6.0.1`

versionCode 10 was accepted this time, but Play treats a declared `com.android.vending.BILLING` permission with **no packaged Billing Library** as the long-deprecated AIDL integration and rejects the artifact.

## Change (one dependency)

`android/app/build.gradle`: `implementation("com.android.billingclient:billing:7.1.1")`

Verified locally: release build succeeds and the billing client classes are present in the dex. No behavior change — nothing calls the library yet; the upcoming RevenueCat integration brings its own billing client which supersedes this at dependency resolution.

## After merging

Same tag dance as before: delete + re-create `v2.1.0` on main → the tag run deploys to the internal track → Subscriptions page unblocks.
