### PR TITLE
fix(billing): sync already-owned purchases, activation-lag message, header PRO badge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,8 @@ Ground truth for saved drills: use a `google_apis` (non-Play) emulator image so 
 
 ## Conventions
 
-- Commit messages: Conventional Commits, `type(scope): description`. No AI attribution/co-author lines.
+- Commit messages: Conventional Commits, `type(scope): description`.
+- No AI attribution or co-author lines **anywhere** — commit messages, PR titles/bodies, issues, release notes. This overrides any tool default that appends a "Generated with …" footer.
 - TypeScript throughout.
 
 ## Gotchas

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Badminton Court Simulator",
     "slug": "badminton-court-simulator",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "scheme": "badminton-court-simulator",
     "orientation": "portrait",
     "icon": "./assets/logo.png",
@@ -22,7 +22,7 @@
         "backgroundColor": "#ffffff"
       },
       "package": "com.haritabhgupta.badmintoncourtsimulator",
-      "versionCode": 11,
+      "versionCode": 12,
       "permissions": ["com.android.vending.BILLING"],
       "intentFilters": [
         {

--- a/components/BadmintonCourt.tsx
+++ b/components/BadmintonCourt.tsx
@@ -322,6 +322,11 @@ export default function BadmintonCourt() {
             style={({ pressed }) => [styles.headerAction, pressed && styles.glassPressed]}
           >
             <MaterialCommunityIcons name="treasure-chest" size={20} color={palette.accent} />
+            {vault.isSubscribed && (
+              <View style={styles.proBadge}>
+                <Text style={styles.proBadgeText}>PRO</Text>
+              </View>
+            )}
           </Pressable>
           <Pressable
             onPress={() => setIsMenuVisible(true)}
@@ -434,6 +439,22 @@ const styles = StyleSheet.create({
   },
   glassPressed: {
     backgroundColor: 'rgba(6, 26, 18, 0.62)',
+  },
+  proBadge: {
+    position: 'absolute',
+    bottom: -5,
+    alignSelf: 'center',
+    backgroundColor: palette.accent,
+    borderRadius: radii.pill,
+    paddingHorizontal: 5,
+    paddingVertical: 1,
+    ...shadows.card,
+  },
+  proBadgeText: {
+    ...sora('700'),
+    fontSize: 8,
+    letterSpacing: 0.6,
+    color: palette.onAccent,
   },
   dock: {
     marginHorizontal: 14,

--- a/hooks/useVaultAccess.ts
+++ b/hooks/useVaultAccess.ts
@@ -3,6 +3,7 @@ import { Linking } from 'react-native';
 import Purchases, {
   CustomerInfo,
   PACKAGE_TYPE,
+  PURCHASES_ERROR_CODE,
   PurchasesPackage,
 } from 'react-native-purchases';
 
@@ -93,9 +94,22 @@ export function useVaultAccess() {
       try {
         const { customerInfo: info } = await Purchases.purchasePackage(pkg);
         setCustomerInfo(info);
-        return hasPro(info);
+        if (!hasPro(info)) {
+          throw new Error(
+            'Payment went through, but Pro has not activated yet. ' +
+              'Tap "Restore purchases" in a minute — if it persists, contact support.'
+          );
+        }
+        return true;
       } catch (error) {
-        if ((error as { userCancelled?: boolean })?.userCancelled) return false;
+        const err = error as { userCancelled?: boolean; code?: string };
+        if (err?.userCancelled) return false;
+        if (err?.code === PURCHASES_ERROR_CODE.PRODUCT_ALREADY_PURCHASED_ERROR) {
+          // Play refuses to sell what the account already owns — sync instead.
+          const info = await Purchases.restorePurchases();
+          setCustomerInfo(info);
+          return hasPro(info);
+        }
         throw error;
       }
     },


### PR DESCRIPTION
## Fixes from the first real internal-track purchase test

1. **"Already subscribed" error on re-tap** — Play refuses to re-sell an owned subscription (`PRODUCT_ALREADY_PURCHASED`). `subscribe()` now treats that as a sync: it restores purchases and resolves with the entitlement state instead of throwing.
2. **Silent no-unlock after successful payment** — when a purchase completes but the `pro` entitlement isn't active in the returned customer info (entitlement misconfiguration in RC, or validation lag), the paywall previously did nothing. It now shows a clear message directing to *Restore purchases*.
3. **Header PRO badge** — small amber `PRO` pill pinned to the treasure-chest header button while the subscription is active, so Pro state is visible without opening the vault.
4. 2.2.1 / versionCode 12.

Root cause of the field failure itself was RC-side (the `pro` entitlement wasn't attached to the Play products) — fixed in the dashboard; these changes make the app resilient and communicative when config or timing is off.

## Test plan
- tsc / eslint / 61 jest tests clean
- On device (internal track after tag v2.2.1): re-tap Subscribe while subscribed → syncs quietly instead of erroring; PRO badge appears in header; Restore path unchanged
