### PR TITLE
feat(drills): save vault drills into My Drills as personal copies

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Badminton Court Simulator",
     "slug": "badminton-court-simulator",
-    "version": "2.2.1",
+    "version": "2.3.0",
     "scheme": "badminton-court-simulator",
     "orientation": "portrait",
     "icon": "./assets/logo.png",
@@ -22,7 +22,7 @@
         "backgroundColor": "#ffffff"
       },
       "package": "com.haritabhgupta.badmintoncourtsimulator",
-      "versionCode": 12,
+      "versionCode": 13,
       "permissions": ["com.android.vending.BILLING"],
       "intentFilters": [
         {

--- a/components/BadmintonCourt.tsx
+++ b/components/BadmintonCourt.tsx
@@ -222,6 +222,19 @@ export default function BadmintonCourt() {
     loadNormalizedSteps(drillStepsForCourt(drill.steps, courtDimensions), drill.isDoubles);
   };
 
+  // Saving a vault drill makes it a personal copy in My Drills: it goes
+  // through the same cap rules as any save and outlives the subscription.
+  const handleSaveVaultDrill = async (drill: VaultDrill) => {
+    const stepSet: StepSet = {
+      id: `vault-${drill.id}-${Date.now()}`,
+      name: drill.name,
+      isDoubles: drill.isDoubles,
+      steps: drillStepsForCourt(drill.steps, courtDimensions),
+      createdAt: Date.now(),
+    };
+    return (await saveStepSet(stepSet)) !== null;
+  };
+
   return (
     <View style={styles.container} onLayout={onRootLayout}>
       {/* Full-bleed court */}
@@ -384,6 +397,7 @@ export default function BadmintonCourt() {
         onDeleteStepSet={deleteStepSet}
         onImport={handleImportStepSet}
         onLoadDrill={handleLoadVaultDrill}
+        onSaveDrill={handleSaveVaultDrill}
       />
     </View>
   );

--- a/components/DrillHubPanel.tsx
+++ b/components/DrillHubPanel.tsx
@@ -35,6 +35,8 @@ interface DrillHubPanelProps {
   onDeleteStepSet: (id: string) => Promise<void>;
   onImport: (stepSet: StepSet) => Promise<void>;
   onLoadDrill: (drill: VaultDrill) => void;
+  /** Saves a personal copy into My Drills; false when rejected (free-tier cap). */
+  onSaveDrill: (drill: VaultDrill) => Promise<boolean>;
 }
 
 interface ListActionProps {
@@ -77,6 +79,7 @@ export function DrillHubPanel({
   onDeleteStepSet,
   onImport,
   onLoadDrill,
+  onSaveDrill,
 }: DrillHubPanelProps) {
   const { isSubscribed, plans, subscribe, restore, manageSubscription } = vault;
   const [activeTab, setActiveTab] = useState<DrillHubTab>(initialTab);
@@ -107,6 +110,22 @@ export function DrillHubPanel({
     }
     onLoadDrill(drill);
     onClose();
+  };
+
+  const handleSaveDrill = async (drill: VaultDrill) => {
+    if (drill.premium && !isSubscribed) {
+      setPaywallVisible(true);
+      return;
+    }
+    if (stepSets.some((stepSet) => stepSet.name === drill.name)) {
+      appAlert('Already saved', `"${drill.name}" is already in My Drills.`);
+      return;
+    }
+    const saved = await onSaveDrill(drill);
+    if (saved) {
+      appAlert('Saved', `"${drill.name}" is now in My Drills — yours to keep and edit.`);
+    }
+    // false = cap reached; the save hook already showed the upgrade prompt.
   };
 
   const handleSubscribe = async () => {
@@ -430,6 +449,7 @@ export function DrillHubPanel({
                 <ScrollView style={styles.list} contentContainerStyle={styles.listContent}>
                   {drills.map((drill) => {
                     const locked = drill.premium && !isSubscribed;
+                    const isSaved = stepSets.some((stepSet) => stepSet.name === drill.name);
                     return (
                       <TouchableOpacity
                         key={drill.id}
@@ -463,12 +483,27 @@ export function DrillHubPanel({
                             </View>
                           )}
                         </View>
-                        <View style={[styles.cardAction, locked && styles.cardActionLocked]}>
-                          <MaterialCommunityIcons
-                            name={locked ? 'lock' : 'play'}
-                            size={18}
-                            color={locked ? palette.textMuted : palette.onAccent}
-                          />
+                        <View style={styles.cardActions}>
+                          <View style={[styles.cardAction, locked && styles.cardActionLocked]}>
+                            <MaterialCommunityIcons
+                              name={locked ? 'lock' : 'play'}
+                              size={18}
+                              color={locked ? palette.textMuted : palette.onAccent}
+                            />
+                          </View>
+                          {!locked && (
+                            <TouchableOpacity
+                              style={styles.cardSaveAction}
+                              onPress={() => handleSaveDrill(drill)}
+                              hitSlop={6}
+                            >
+                              <MaterialCommunityIcons
+                                name={isSaved ? 'bookmark-check' : 'bookmark-plus-outline'}
+                                size={18}
+                                color={isSaved ? palette.accent : palette.textPrimary}
+                              />
+                            </TouchableOpacity>
+                          )}
                         </View>
                       </TouchableOpacity>
                     );
@@ -1012,6 +1047,20 @@ const styles = StyleSheet.create({
   cardActionLocked: {
     backgroundColor: 'rgba(255, 255, 255, 0.10)',
     borderColor: 'rgba(255, 255, 255, 0.18)',
+  },
+  cardActions: {
+    alignItems: 'center',
+    gap: 6,
+  },
+  cardSaveAction: {
+    width: 38,
+    height: 38,
+    borderRadius: 19,
+    backgroundColor: 'rgba(255, 255, 255, 0.10)',
+    borderWidth: 1,
+    borderColor: 'rgba(255, 255, 255, 0.18)',
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   dialogOverlay: {
     flex: 1,


### PR DESCRIPTION
## Summary

Vault drills can now be saved directly into **My Drills** as personal copies that outlive the subscription.

- **Bookmark button** on every unlocked vault card (free drills for everyone; premium once subscribed — locked cards still route to the paywall). Saved state shows as a checked bookmark.
- The copy is **court-remapped at save time** (`drillStepsForCourt`) and stored as a regular `StepSet`, so it loads/edits/shares/deletes exactly like a user-created drill with no special-casing downstream.
- Saves go through `saveStepSet`, so the existing rules apply unchanged: free tier counts them against the 5-drill cap (with the Pro upsell at the limit), Pro saves unlimited — and since saved drills live in local storage independent of entitlements, **they persist after cancellation** by construction.
- Duplicate names are rejected with an "Already saved" alert.
- 2.3.0 / versionCode 13.

## Test plan

- tsc / eslint / 61 jest tests clean
- Verified on AVD (unsubscribed free tier): bookmark on a free drill → "Saved" alert → bookmark flips to checked → My Drills shows "1/5 free" with the drill listed and playable — confirming the copy works entirely without an active subscription