### PR TITLE
feat(brand): rename app to Featherwork

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-Badminton court simulator — an Expo (React Native) app using expo-router.
+Featherwork (formerly Badminton Court Simulator) — an Expo (React Native) badminton tactics app using expo-router.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ npx expo run:android --variant release
 ## File Structure
 
 ```
-badminton-court-simulator/
+featherwork/
 ├── components/
 │   ├── BadmintonCourt.tsx          # Main court component
 │   ├── PlayerMarker.tsx            # Draggable player/shuttle markers

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Badminton Court Simulator
+# Featherwork
 
 A React Native app for simulating badminton court positions and movements with enhanced UI using React Native Paper and comprehensive player customization features.
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-  <string name="app_name">Badminton Court Simulator</string>
+  <string name="app_name">Featherwork</string>
   <string name="expo_splash_screen_resize_mode" translatable="false">contain</string>
   <string name="expo_splash_screen_status_bar_translucent" translatable="false">false</string>
   <string name="expo_system_ui_user_interface_style" translatable="false">light</string>

--- a/app.json
+++ b/app.json
@@ -1,8 +1,8 @@
 {
   "expo": {
-    "name": "Badminton Court Simulator",
+    "name": "Featherwork",
     "slug": "badminton-court-simulator",
-    "version": "2.3.0",
+    "version": "2.4.0",
     "scheme": "badminton-court-simulator",
     "orientation": "portrait",
     "icon": "./assets/logo.png",
@@ -22,7 +22,7 @@
         "backgroundColor": "#ffffff"
       },
       "package": "com.haritabhgupta.badmintoncourtsimulator",
-      "versionCode": 13,
+      "versionCode": 14,
       "permissions": ["com.android.vending.BILLING"],
       "intentFilters": [
         {

--- a/links-site/court/import.html
+++ b/links-site/court/import.html
@@ -10,7 +10,7 @@
   </style>
 </head>
 <body>
-  <h1>Badminton Court Simulator</h1>
+  <h1>Featherwork</h1>
   <p id="status">Opening app…</p>
   <p><a id="fallback" href="#">Tap here if the app did not open</a></p>
   <script>

--- a/links-site/court/import/index.html
+++ b/links-site/court/import/index.html
@@ -10,7 +10,7 @@
   </style>
 </head>
 <body>
-  <h1>Badminton Court Simulator</h1>
+  <h1>Featherwork</h1>
   <p id="status">Opening app…</p>
   <p><a id="fallback" href="#">Tap here if the app did not open</a></p>
   <script>

--- a/links-site/i.html
+++ b/links-site/i.html
@@ -10,7 +10,7 @@
   </style>
 </head>
 <body>
-  <h1>Badminton Court Simulator</h1>
+  <h1>Featherwork</h1>
   <p id="status">Opening app…</p>
   <p><a id="fallback" href="#">Tap here if the app did not open</a></p>
   <script>

--- a/utils/stepSharing.ts
+++ b/utils/stepSharing.ts
@@ -477,5 +477,5 @@ export function decodeSharedStepSet(sharedText: string): StepSet | null {
 
 export function getShareMessage(stepSet: StepSet): string {
   const link = encodeStepSetForSharing(stepSet);
-  return `Badminton drill: ${stepSet.name}\n\n${link}\n\nTap the link to open in Badminton Court Simulator, or copy and use Import from clipboard.`;
+  return `Badminton drill: ${stepSet.name}\n\n${link}\n\nTap the link to open in Featherwork, or copy and use Import from clipboard.`;
 }


### PR DESCRIPTION
## Summary

Rebrand from **Badminton Court Simulator** to **Featherwork** (Play listing title becomes `Featherwork: Badminton Drills` — set manually in Play Console).

Display-name-only rename:
- `app.json` name + `strings.xml` app_name → launcher shows **Featherwork** (verified via aapt badging on a release build)
- share message copy, links-site page headings, README/AGENTS.md branding
- 2.4.0 / versionCode 14

**Deliberately untouched** (permanent identity — changing any of these would break existing installs, share links, or subscriptions): package id, deep-link scheme, expo slug, share base URL, product/entitlement ids.

## Test plan
- tsc / eslint / 61 jest tests clean
- Release APK badging shows `application-label:'Featherwork'`
- No functional changes; share-link format unchanged (covered by test suite)