### PR TITLE
feat(court): Together steps, glide transitions, step speed, and drill playback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ adb exec-out screencap -p > screen.png                # inspect UI state
 adb shell input tap X Y / input swipe X1 Y1 X2 Y2 600 # drive it (coords in px)
 ```
 
-Critical user flows to exercise: drag a marker (step count increments), undo/redo/reset, singles/doubles switch (Customize panel), save/load/delete a drill, share link, deep-link import:
+Critical user flows to exercise: drag a marker (step count increments; a tap without a drag must NOT increment), undo/redo/reset (markers glide, ~260ms), Together (arm via dock, drag several pieces — amber rings + count badge, no step yet — tap Together again to commit ONE step; Cancel discards), singles/doubles switch (Customize panel), save/load/delete a drill, share link, deep-link import:
 
 ```bash
 adb shell am start -a android.intent.action.VIEW \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ adb exec-out screencap -p > screen.png                # inspect UI state
 adb shell input tap X Y / input swipe X1 Y1 X2 Y2 600 # drive it (coords in px)
 ```
 
-Critical user flows to exercise: drag a marker (step count increments; a tap without a drag must NOT increment), undo/redo/reset (markers glide, ~260ms), Together (arm via dock, drag several pieces — amber rings + count badge, no step yet — tap Together again to commit ONE step; Cancel discards), singles/doubles switch (Customize panel), save/load/delete a drill, share link, deep-link import:
+Critical user flows to exercise: drag a marker (step count increments; a tap without a drag must NOT increment), undo/redo/reset (markers glide; speed set by the Customize "Step speed" slider), the first dock button (Reset when the stack is empty ↔ Clear when steps exist — Clear keeps positions, wipes the stack), Together (arm via dock, drag several pieces — amber rings + count badge, no step yet — tap Together again to commit ONE step; Cancel discards), drill playback (loading/importing a drill locks the pieces: name pill shows i/n + progress and toggles an info card, Back/Next walk steps, Play autoplays and loops with a ~3-beat hold at the end, Fork unlocks editing at the current step), singles/doubles switch (Customize panel), save/load/delete a drill, share link, deep-link import:
 
 ```bash
 adb shell am start -a android.intent.action.VIEW \

--- a/components/BadmintonCourt.tsx
+++ b/components/BadmintonCourt.tsx
@@ -117,6 +117,10 @@ export default function BadmintonCourt() {
     updatePlayerPosition,
     updateShuttlePosition,
     handlePositionChangeComplete,
+    isTogether,
+    toggleTogether,
+    cancelTogether,
+    togetherMoved,
     toggleGameMode,
     resetPositions,
     undo,
@@ -131,6 +135,10 @@ export default function BadmintonCourt() {
     loadNormalizedSteps,
     stepCount,
   } = useCourtPositions(courtDimensions);
+
+  const togetherCount = togetherMoved
+    ? [...togetherMoved.team1, ...togetherMoved.team2, togetherMoved.shuttle].filter(Boolean).length
+    : 0;
 
   // Once the real court area is measured, re-seed the default positions —
   // but only while the board is pristine (nothing moved, no history).
@@ -280,6 +288,7 @@ export default function BadmintonCourt() {
           isLeftHanded={customizations[index === 0 ? 'P1' : 'P2'].isLeftHanded}
           icon={customizations[index === 0 ? 'P1' : 'P2'].icon}
           iconType={customizations[index === 0 ? 'P1' : 'P2'].iconType}
+          linked={!!togetherMoved?.team1[index]}
           onPositionChange={(newPos) => updatePlayerPosition('team1', index, newPos)}
           onPositionStart={(newPos) => updatePlayerPosition('team1', index, newPos, true)}
           onPositionChangeComplete={handlePositionChangeComplete}
@@ -297,6 +306,7 @@ export default function BadmintonCourt() {
           isLeftHanded={customizations[index === 0 ? 'P3' : 'P4'].isLeftHanded}
           icon={customizations[index === 0 ? 'P3' : 'P4'].icon}
           iconType={customizations[index === 0 ? 'P3' : 'P4'].iconType}
+          linked={!!togetherMoved?.team2[index]}
           onPositionChange={(newPos) => updatePlayerPosition('team2', index, newPos)}
           onPositionStart={(newPos) => updatePlayerPosition('team2', index, newPos, true)}
           onPositionChangeComplete={handlePositionChangeComplete}
@@ -312,6 +322,7 @@ export default function BadmintonCourt() {
         size={customizations.Shuttle.size}
         icon={customizations.Shuttle.icon}
         iconType={customizations.Shuttle.iconType}
+        linked={!!togetherMoved?.shuttle}
         onPositionChange={updateShuttlePosition}
         onPositionStart={(newPos) => updateShuttlePosition(newPos, true)}
         onPositionChangeComplete={handlePositionChangeComplete}
@@ -351,14 +362,46 @@ export default function BadmintonCourt() {
         </View>
       </View>
 
+      {/* Armed-Together banner (visual only; never blocks drags underneath) */}
+      {isTogether && (
+        <View
+          style={[styles.togetherBanner, { top: headerTop + HEADER_HEIGHT + spacing.md }]}
+          pointerEvents="none"
+        >
+          <MaterialCommunityIcons name="link-variant" size={17} color={palette.accent} />
+          <View style={styles.togetherBannerText}>
+            <Text style={styles.togetherBannerTitle}>Together is on — drag any pieces</Text>
+            <Text style={styles.togetherBannerBody}>
+              They&apos;ll move as one step · Together saves · Cancel discards
+            </Text>
+          </View>
+        </View>
+      )}
+
       {/* Court area spacer between header and dock — its measured rect hosts the lines */}
       <View style={styles.courtArea} pointerEvents="none" onLayout={onCourtAreaLayout} />
 
       {/* Floating bottom dock */}
       <View style={[styles.dock, { marginBottom: dockBottom }]}>
-        <IconButton icon="restart" label="Reset" onPress={resetPositions} />
-        <IconButton icon="undo-variant" label="Undo" onPress={undo} disabled={!canUndo} />
-        <IconButton icon="redo-variant" label="Redo" onPress={redo} disabled={!canRedo} />
+        {isTogether ? (
+          <IconButton
+            icon="close-circle-outline"
+            label="Cancel"
+            color={palette.danger}
+            onPress={cancelTogether}
+          />
+        ) : (
+          <IconButton icon="restart" label="Reset" onPress={resetPositions} />
+        )}
+        <IconButton icon="undo-variant" label="Undo" onPress={undo} disabled={!canUndo || isTogether} />
+        <IconButton icon="redo-variant" label="Redo" onPress={redo} disabled={!canRedo || isTogether} />
+        <IconButton
+          icon="link-variant"
+          label="Together"
+          onPress={toggleTogether}
+          active={isTogether}
+          badge={togetherCount}
+        />
         <IconButton
           icon="shoe-print"
           label="Trails"
@@ -469,6 +512,36 @@ const styles = StyleSheet.create({
     fontSize: 8,
     letterSpacing: 0.6,
     color: palette.onAccent,
+  },
+  // Amber glass per the Together mockup (opacity bumped: no backdrop blur on RN).
+  togetherBanner: {
+    position: 'absolute',
+    left: spacing.lg,
+    right: spacing.lg,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.lg,
+    borderRadius: radii.md,
+    backgroundColor: 'rgba(35, 22, 4, 0.78)',
+    borderWidth: 1.5,
+    borderColor: 'rgba(255, 201, 77, 0.75)',
+    ...shadows.card,
+  },
+  togetherBannerText: {
+    flex: 1,
+    gap: 2,
+  },
+  togetherBannerTitle: {
+    ...sora('600'),
+    fontSize: 12,
+    color: '#FFE4A6',
+  },
+  togetherBannerBody: {
+    ...sora('400'),
+    fontSize: 10.5,
+    color: 'rgba(255, 228, 166, 0.75)',
   },
   dock: {
     marginHorizontal: 14,

--- a/components/BadmintonCourt.tsx
+++ b/components/BadmintonCourt.tsx
@@ -16,7 +16,7 @@ import { drillStepsForCourt, VaultDrill } from '../data/vaultDrills';
 import { useVaultAccess } from '../hooks/useVaultAccess';
 import { useMarkerCustomization } from '../context/MarkerCustomizationContext';
 import { createStepSet, decodeSharedStepSet } from '../utils/stepSharing';
-import { StepSet } from '../types/drill';
+import { NormalizedStep, StepSet } from '../types/drill';
 import { palette, radii, shadows, sora, spacing } from '../constants/theme';
 
 const HEADER_HEIGHT = 44;
@@ -35,6 +35,60 @@ const consumedShareUrls = new Set<string>();
 const liveApplyImport: {
   current: ((stepSet: StepSet, replaceId?: string) => void) | null;
 } = { current: null };
+
+// Steps where more than one piece moved vs the previous step (Together steps).
+function countTogetherSteps(steps: NormalizedStep[]): number {
+  let count = 0;
+  for (let i = 1; i < steps.length; i++) {
+    const prev = steps[i - 1];
+    const step = steps[i];
+    let moved = 0;
+    (['team1', 'team2'] as const).forEach((team) =>
+      step.players[team].forEach((pos, j) => {
+        const was = prev.players[team][j];
+        if (was && (was.x !== pos.x || was.y !== pos.y)) moved++;
+      })
+    );
+    if (step.shuttle.x !== prev.shuttle.x || step.shuttle.y !== prev.shuttle.y) moved++;
+    if (moved > 1) count++;
+  }
+  return count;
+}
+
+interface LoadedDrillMeta {
+  name: string;
+  description?: string;
+  chips: string[];
+}
+
+const stepSetMeta = (stepSet: StepSet): LoadedDrillMeta => {
+  const together = countTogetherSteps(stepSet.steps);
+  return {
+    name: stepSet.name,
+    chips: [
+      `${stepSet.steps.length} steps`,
+      stepSet.isDoubles ? 'Doubles' : 'Singles',
+      ...(together > 0
+        ? [`${together} together ${together === 1 ? 'step' : 'steps'}`]
+        : []),
+      `Saved ${new Date(stepSet.createdAt).toLocaleDateString(undefined, {
+        day: 'numeric',
+        month: 'short',
+      })}`,
+    ],
+  };
+};
+
+const vaultMeta = (drill: VaultDrill, steps: NormalizedStep[]): LoadedDrillMeta => ({
+  name: drill.name,
+  description: drill.description,
+  chips: [
+    `${steps.length} steps`,
+    drill.isDoubles ? 'Doubles' : 'Singles',
+    drill.category,
+    drill.difficulty,
+  ],
+});
 
 export default function BadmintonCourt() {
   const insets = useSafeAreaInsets();
@@ -94,6 +148,13 @@ export default function BadmintonCourt() {
   const [isMenuVisible, setIsMenuVisible] = useState(false);
   // null = drill hub closed; otherwise the tab it opens on.
   const [drillHubTab, setDrillHubTab] = useState<DrillHubTab | null>(null);
+  // Glide duration between steps (ms); set from the Customize panel slider.
+  const [stepAnimationMs, setStepAnimationMs] = useState(260);
+  // Playback state for the loaded drill.
+  const [loadedDrill, setLoadedDrill] = useState<LoadedDrillMeta | null>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [infoOpen, setInfoOpen] = useState(false);
+  const [lockBannerDismissed, setLockBannerDismissed] = useState(false);
   const { customizations, updateMarkerCustomization } = useMarkerCustomization();
   const vault = useVaultAccess();
   const { stepSets, saveStepSet, deleteStepSet, replaceStepSet, importStepSet } = useStepSets({
@@ -121,8 +182,12 @@ export default function BadmintonCourt() {
     toggleTogether,
     cancelTogether,
     togetherMoved,
+    isPlayback,
+    exitPlayback,
+    goToStart,
     toggleGameMode,
     resetPositions,
+    clearSteps,
     undo,
     redo,
     canUndo,
@@ -134,6 +199,7 @@ export default function BadmintonCourt() {
     getStepsSnapshot,
     loadNormalizedSteps,
     stepCount,
+    totalSteps,
   } = useCourtPositions(courtDimensions);
 
   const togetherCount = togetherMoved
@@ -146,20 +212,77 @@ export default function BadmintonCourt() {
     ? `${Math.round(courtArea.y)}:${Math.round(courtArea.width)}:${Math.round(courtArea.height)}`
     : '';
   useEffect(() => {
-    if (measuredKey && !canUndo && !canRedo) {
+    if (measuredKey && !canUndo && !canRedo && !isPlayback) {
       resetPositions();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [measuredKey]);
+
+  // Autoplay: one step per tick, paced by the step-speed setting. At the last
+  // step, hold ~3 beats, then loop from the start.
+  const loopHoldRef = useRef(0);
+  useEffect(() => {
+    if (!isPlaying || !isPlayback) return;
+    const id = setInterval(() => {
+      if (canRedo) {
+        loopHoldRef.current = 0;
+        redo();
+      } else if (++loopHoldRef.current >= 3) {
+        loopHoldRef.current = 0;
+        goToStart();
+      }
+    }, stepAnimationMs + 700);
+    return () => clearInterval(id);
+  }, [canRedo, goToStart, isPlayback, isPlaying, redo, stepAnimationMs]);
+
+  const togglePlay = useCallback(() => {
+    if (isPlaying) {
+      setIsPlaying(false);
+      return;
+    }
+    if (!canRedo) goToStart(); // at the end: replay from the top
+    loopHoldRef.current = 0;
+    setIsPlaying(true);
+  }, [canRedo, goToStart, isPlaying]);
+
+  const stepBack = useCallback(() => {
+    setIsPlaying(false);
+    undo();
+  }, [undo]);
+
+  const stepNext = useCallback(() => {
+    setIsPlaying(false);
+    redo();
+  }, [redo]);
+
+  // Fork: unlock the loaded drill for editing at the current step.
+  const handleFork = useCallback(() => {
+    setIsPlaying(false);
+    setInfoOpen(false);
+    setLoadedDrill(null);
+    exitPlayback();
+  }, [exitPlayback]);
+
+  const beginPlayback = useCallback((
+    steps: NormalizedStep[],
+    nextIsDoubles: boolean,
+    meta: LoadedDrillMeta
+  ) => {
+    loadNormalizedSteps(steps, nextIsDoubles);
+    setLoadedDrill(meta);
+    setIsPlaying(false);
+    setInfoOpen(false);
+    setLockBannerDismissed(false);
+  }, [loadNormalizedSteps]);
 
   const applyImport = useCallback(async (stepSet: StepSet, replaceId?: string) => {
     const saved = replaceId
       ? await replaceStepSet(replaceId, stepSet)
       : await importStepSet(stepSet);
     if (!saved) return; // drill limit reached; the hook already alerted
-    loadNormalizedSteps(saved.steps, saved.isDoubles);
+    beginPlayback(saved.steps, saved.isDoubles, stepSetMeta(saved));
     appAlert('Imported', `"${saved.name}" has been imported and loaded.`);
-  }, [importStepSet, loadNormalizedSteps, replaceStepSet]);
+  }, [beginPlayback, importStepSet, replaceStepSet]);
 
   useEffect(() => {
     liveApplyImport.current = applyImport;
@@ -221,13 +344,14 @@ export default function BadmintonCourt() {
   }, [getStepsSnapshot, isDoubles, saveStepSet, screenHeight, screenWidth]);
 
   const handleLoadStepSet = useCallback((stepSet: StepSet) => {
-    loadNormalizedSteps(stepSet.steps, stepSet.isDoubles);
-  }, [loadNormalizedSteps]);
+    beginPlayback(stepSet.steps, stepSet.isDoubles, stepSetMeta(stepSet));
+  }, [beginPlayback]);
 
   // Vault drills are authored in a fixed court frame; remap them onto the
   // measured lines rect so they land on the painted court of this device.
   const handleLoadVaultDrill = (drill: VaultDrill) => {
-    loadNormalizedSteps(drillStepsForCourt(drill.steps, courtDimensions), drill.isDoubles);
+    const steps = drillStepsForCourt(drill.steps, courtDimensions);
+    beginPlayback(steps, drill.isDoubles, vaultMeta(drill, steps));
   };
 
   // Saving a vault drill makes it a personal copy in My Drills: it goes
@@ -289,6 +413,8 @@ export default function BadmintonCourt() {
           icon={customizations[index === 0 ? 'P1' : 'P2'].icon}
           iconType={customizations[index === 0 ? 'P1' : 'P2'].iconType}
           linked={!!togetherMoved?.team1[index]}
+          glideMs={stepAnimationMs}
+          locked={isPlayback}
           onPositionChange={(newPos) => updatePlayerPosition('team1', index, newPos)}
           onPositionStart={(newPos) => updatePlayerPosition('team1', index, newPos, true)}
           onPositionChangeComplete={handlePositionChangeComplete}
@@ -307,6 +433,8 @@ export default function BadmintonCourt() {
           icon={customizations[index === 0 ? 'P3' : 'P4'].icon}
           iconType={customizations[index === 0 ? 'P3' : 'P4'].iconType}
           linked={!!togetherMoved?.team2[index]}
+          glideMs={stepAnimationMs}
+          locked={isPlayback}
           onPositionChange={(newPos) => updatePlayerPosition('team2', index, newPos)}
           onPositionStart={(newPos) => updatePlayerPosition('team2', index, newPos, true)}
           onPositionChangeComplete={handlePositionChangeComplete}
@@ -323,6 +451,8 @@ export default function BadmintonCourt() {
         icon={customizations.Shuttle.icon}
         iconType={customizations.Shuttle.iconType}
         linked={!!togetherMoved?.shuttle}
+        glideMs={stepAnimationMs}
+        locked={isPlayback}
         onPositionChange={updateShuttlePosition}
         onPositionStart={(newPos) => updateShuttlePosition(newPos, true)}
         onPositionChangeComplete={handlePositionChangeComplete}
@@ -331,14 +461,37 @@ export default function BadmintonCourt() {
         onIconChange={(icon) => updateMarkerCustomization('Shuttle', { icon })}
       />
 
-      {/* Floating header: mode status pill + customize button */}
+      {/* Floating header: mode/drill pill + customize button (stays Settings
+          in playback too; the banner ✕ is the only dismiss control) */}
       <View style={[styles.header, { marginTop: headerTop }]} pointerEvents="box-none">
-        <View style={styles.modePill}>
-          <MaterialCommunityIcons name="badminton" size={18} color={palette.textPrimary} />
-          <Text style={styles.modePillLabel}>
-            {isDoubles ? 'Doubles' : 'Singles'} · Step {stepCount}
-          </Text>
-        </View>
+        {isPlayback && loadedDrill ? (
+          <Pressable style={styles.namePill} onPress={() => setInfoOpen((open) => !open)}>
+            <MaterialCommunityIcons name="playlist-play" size={17} color={palette.textPrimary} />
+            <Text style={styles.namePillLabel} numberOfLines={1}>
+              {loadedDrill.name}
+            </Text>
+            <MaterialCommunityIcons
+              name={infoOpen ? 'chevron-up' : 'chevron-down'}
+              size={14}
+              color={palette.textSecondary}
+            />
+            <Text style={[styles.namePillCount, isPlaying && { color: palette.accent }]}>
+              {stepCount}/{totalSteps}
+            </Text>
+            <View style={styles.namePillTrack}>
+              <View
+                style={[styles.namePillFill, { width: `${(stepCount / totalSteps) * 100}%` }]}
+              />
+            </View>
+          </Pressable>
+        ) : (
+          <View style={styles.modePill}>
+            <MaterialCommunityIcons name="badminton" size={18} color={palette.textPrimary} />
+            <Text style={styles.modePillLabel}>
+              {isDoubles ? 'Doubles' : 'Singles'} · Step {stepCount}
+            </Text>
+          </View>
+        )}
         <View style={styles.headerActions}>
           <Pressable
             onPress={() => setDrillHubTab('vault')}
@@ -362,6 +515,58 @@ export default function BadmintonCourt() {
         </View>
       </View>
 
+      {/* Playback lock banner (✕ dismisses just the banner) */}
+      {isPlayback && !lockBannerDismissed && !infoOpen && (
+        <View
+          style={[styles.lockBanner, { top: headerTop + HEADER_HEIGHT + spacing.md }]}
+          pointerEvents="box-none"
+        >
+          <MaterialCommunityIcons name="lock-outline" size={17} color={palette.textPrimary} />
+          <View style={styles.bannerText}>
+            <Text style={styles.lockBannerTitle}>Drill loaded — pieces are locked</Text>
+            <Text style={styles.lockBannerBody}>
+              Walk the steps with Back / Next, or press Play
+            </Text>
+            <Text style={styles.lockBannerBody}>
+              <Text style={styles.lockBannerAccent}>Fork</Text> copies the drill so you can edit
+              from this step
+            </Text>
+          </View>
+          <Pressable
+            onPress={() => setLockBannerDismissed(true)}
+            hitSlop={8}
+            style={styles.bannerClose}
+          >
+            <MaterialCommunityIcons name="close" size={13} color={palette.textPrimary} />
+          </Pressable>
+        </View>
+      )}
+
+      {/* Drill info card (tap the name pill to toggle) */}
+      {isPlayback && infoOpen && loadedDrill && (
+        <View
+          style={[styles.infoCard, { top: headerTop + HEADER_HEIGHT + spacing.md }]}
+          pointerEvents="box-none"
+        >
+          <View style={styles.infoCardHeader}>
+            <Text style={styles.infoCardTitle} numberOfLines={1}>
+              {loadedDrill.name}
+            </Text>
+            <Text style={styles.infoCardHint}>tap name to close</Text>
+          </View>
+          {loadedDrill.description ? (
+            <Text style={styles.infoCardBody}>{loadedDrill.description}</Text>
+          ) : null}
+          <View style={styles.chipRow}>
+            {loadedDrill.chips.map((chip) => (
+              <View key={chip} style={styles.chip}>
+                <Text style={styles.chipText}>{chip}</Text>
+              </View>
+            ))}
+          </View>
+        </View>
+      )}
+
       {/* Armed-Together banner (visual only; never blocks drags underneath) */}
       {isTogether && (
         <View
@@ -383,25 +588,44 @@ export default function BadmintonCourt() {
 
       {/* Floating bottom dock */}
       <View style={[styles.dock, { marginBottom: dockBottom }]}>
-        {isTogether ? (
-          <IconButton
-            icon="close-circle-outline"
-            label="Cancel"
-            color={palette.danger}
-            onPress={cancelTogether}
-          />
+        {isPlayback ? (
+          <>
+            <IconButton icon="source-fork" label="Fork" onPress={handleFork} />
+            <IconButton icon="step-backward" label="Back" onPress={stepBack} disabled={!canUndo} />
+            <IconButton icon="step-forward" label="Next" onPress={stepNext} disabled={!canRedo} />
+            <IconButton
+              icon={isPlaying ? 'pause' : 'play'}
+              label={isPlaying ? 'Pause' : 'Play'}
+              onPress={togglePlay}
+              active
+            />
+          </>
         ) : (
-          <IconButton icon="restart" label="Reset" onPress={resetPositions} />
+          <>
+            {isTogether ? (
+              <IconButton
+                icon="close-circle-outline"
+                label="Cancel"
+                color={palette.danger}
+                onPress={cancelTogether}
+              />
+            ) : totalSteps > 1 ? (
+              // Wipe the stack but keep positions — for staging a start formation.
+              <IconButton icon="broom" label="Clear" onPress={clearSteps} />
+            ) : (
+              <IconButton icon="restart" label="Reset" onPress={resetPositions} />
+            )}
+            <IconButton icon="undo-variant" label="Undo" onPress={undo} disabled={!canUndo || isTogether} />
+            <IconButton icon="redo-variant" label="Redo" onPress={redo} disabled={!canRedo || isTogether} />
+            <IconButton
+              icon="link-variant"
+              label="Together"
+              onPress={toggleTogether}
+              active={isTogether}
+              badge={togetherCount}
+            />
+          </>
         )}
-        <IconButton icon="undo-variant" label="Undo" onPress={undo} disabled={!canUndo || isTogether} />
-        <IconButton icon="redo-variant" label="Redo" onPress={redo} disabled={!canRedo || isTogether} />
-        <IconButton
-          icon="link-variant"
-          label="Together"
-          onPress={toggleTogether}
-          active={isTogether}
-          badge={togetherCount}
-        />
         <IconButton
           icon="shoe-print"
           label="Trails"
@@ -426,6 +650,8 @@ export default function BadmintonCourt() {
         onClose={() => setIsMenuVisible(false)}
         isDoubles={isDoubles}
         onGameModeChange={toggleGameMode}
+        stepAnimationMs={stepAnimationMs}
+        onStepAnimationChange={setStepAnimationMs}
       />
 
       <DrillHubPanel
@@ -512,6 +738,146 @@ const styles = StyleSheet.create({
     fontSize: 8,
     letterSpacing: 0.6,
     color: palette.onAccent,
+  },
+  // Drill name pill: like the mode pill, plus a step progress bar at the bottom.
+  namePill: {
+    height: HEADER_HEIGHT + 2,
+    maxWidth: '78%',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingLeft: 13,
+    paddingRight: 15,
+    paddingBottom: 7,
+    borderRadius: radii.pill,
+    backgroundColor: palette.glassPill,
+    borderWidth: 1,
+    borderColor: palette.glassPillBorder,
+    overflow: 'hidden',
+    ...shadows.card,
+  },
+  namePillLabel: {
+    ...sora('600'),
+    fontSize: 13,
+    color: palette.textPrimary,
+    flexShrink: 1,
+    maxWidth: 150,
+  },
+  namePillCount: {
+    ...sora('600'),
+    fontSize: 11,
+    letterSpacing: 0.4,
+    color: palette.textMuted,
+  },
+  namePillTrack: {
+    position: 'absolute',
+    left: 13,
+    right: 13,
+    bottom: 6,
+    height: 3,
+    borderRadius: 2,
+    backgroundColor: 'rgba(255, 255, 255, 0.16)',
+  },
+  namePillFill: {
+    height: '100%',
+    borderRadius: 2,
+    backgroundColor: palette.accent,
+  },
+  lockBanner: {
+    position: 'absolute',
+    left: spacing.lg,
+    right: spacing.lg,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.lg,
+    borderRadius: radii.md,
+    backgroundColor: 'rgba(6, 26, 18, 0.82)',
+    borderWidth: 1.5,
+    borderColor: 'rgba(255, 255, 255, 0.3)',
+    ...shadows.card,
+  },
+  bannerText: {
+    flex: 1,
+    gap: 2,
+  },
+  lockBannerTitle: {
+    ...sora('600'),
+    fontSize: 12,
+    color: palette.textPrimary,
+  },
+  lockBannerBody: {
+    ...sora('400'),
+    fontSize: 10.5,
+    color: 'rgba(255, 255, 255, 0.7)',
+  },
+  lockBannerAccent: {
+    ...sora('600'),
+    color: palette.accent,
+  },
+  bannerClose: {
+    width: 34,
+    height: 34,
+    borderRadius: 17,
+    backgroundColor: 'rgba(255, 255, 255, 0.1)',
+    borderWidth: 1,
+    borderColor: 'rgba(255, 255, 255, 0.22)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  infoCard: {
+    position: 'absolute',
+    left: spacing.lg,
+    right: spacing.lg,
+    gap: spacing.sm,
+    paddingVertical: 15,
+    paddingHorizontal: spacing.lg,
+    borderRadius: 20,
+    backgroundColor: 'rgba(6, 26, 18, 0.92)',
+    borderWidth: 1,
+    borderColor: 'rgba(255, 255, 255, 0.25)',
+    ...shadows.floating,
+  },
+  infoCardHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  infoCardTitle: {
+    ...sora('700'),
+    fontSize: 15,
+    color: palette.textPrimary,
+    flex: 1,
+  },
+  infoCardHint: {
+    ...sora('400'),
+    fontSize: 10,
+    color: palette.textMuted,
+  },
+  infoCardBody: {
+    ...sora('400'),
+    fontSize: 11.5,
+    lineHeight: 18,
+    color: 'rgba(255, 255, 255, 0.75)',
+  },
+  chipRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 6,
+  },
+  chip: {
+    paddingVertical: 5,
+    paddingHorizontal: 10,
+    borderRadius: radii.pill,
+    backgroundColor: 'rgba(255, 255, 255, 0.08)',
+    borderWidth: 1,
+    borderColor: 'rgba(255, 255, 255, 0.12)',
+  },
+  chipText: {
+    ...sora('600'),
+    fontSize: 10,
+    color: 'rgba(255, 255, 255, 0.8)',
   },
   // Amber glass per the Together mockup (opacity bumped: no backdrop blur on RN).
   togetherBanner: {

--- a/components/IconButton.tsx
+++ b/components/IconButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Pressable, StyleSheet, Text } from 'react-native';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { palette, sora } from '../constants/theme';
 
@@ -10,6 +10,10 @@ interface IconButtonProps {
   active?: boolean;
   size?: number;
   label?: string;
+  /** Tint for the icon when not active (e.g. palette.danger for Cancel). */
+  color?: string;
+  /** Small count bubble at the top-right corner; hidden when 0/undefined. */
+  badge?: number;
 }
 
 export function IconButton({
@@ -19,8 +23,10 @@ export function IconButton({
   active = false,
   size = 20,
   label,
+  color,
+  badge,
 }: IconButtonProps) {
-  const iconColor = active ? palette.onAccent : 'rgba(255, 255, 255, 0.85)';
+  const iconColor = active ? palette.onAccent : color ?? 'rgba(255, 255, 255, 0.85)';
 
   return (
     <Pressable
@@ -39,6 +45,11 @@ export function IconButton({
         <Text style={[styles.label, active && styles.activeLabel]} numberOfLines={1}>
           {label}
         </Text>
+      ) : null}
+      {badge ? (
+        <View style={styles.badge}>
+          <Text style={styles.badgeText}>{badge}</Text>
+        </View>
       ) : null}
     </Pressable>
   );
@@ -74,5 +85,24 @@ const styles = StyleSheet.create({
   activeLabel: {
     ...sora('700'),
     color: palette.onAccent,
+  },
+  badge: {
+    position: 'absolute',
+    top: -5,
+    right: 1,
+    minWidth: 18,
+    height: 18,
+    borderRadius: 9,
+    paddingHorizontal: 4,
+    backgroundColor: palette.onAccent,
+    borderWidth: 1.5,
+    borderColor: palette.accent,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  badgeText: {
+    ...sora('700'),
+    fontSize: 10,
+    color: palette.accent,
   },
 });

--- a/components/PlayerMarker.tsx
+++ b/components/PlayerMarker.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { View, StyleSheet, GestureResponderEvent, Modal, TouchableOpacity, Text, Dimensions, Image } from 'react-native';
+import { Animated, Easing, View, StyleSheet, GestureResponderEvent, Modal, TouchableOpacity, Text, Dimensions, Image } from 'react-native';
 import { Text as PaperText } from 'react-native-paper';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { AppSlider } from './AppSlider';
@@ -21,6 +21,8 @@ interface PlayerMarkerProps {
   isLeftHanded?: boolean;
   icon?: string;
   iconType?: 'icon' | 'text' | 'photo';
+  /** Amber ring: this piece is part of the armed Together step. */
+  linked?: boolean;
   onPositionChange?: (newPosition: { x: number; y: number }) => void;
   onPositionStart?: (newPosition: { x: number; y: number }) => void;
   onPositionChangeComplete?: () => void;
@@ -36,15 +38,16 @@ const availableIcons = [
   'basketball', 'volleyball', 'tennis', 'star', 'heart'
 ];
 
-export function PlayerMarker({ 
-  position, 
-  color, 
+export function PlayerMarker({
+  position,
+  color,
   size,
   isLeftHanded,
   icon = 'account',
   iconType = 'icon',
-  onPositionChange, 
-  onPositionStart, 
+  linked = false,
+  onPositionChange,
+  onPositionStart,
   onPositionChangeComplete,
   onColorChange,
   onSizeChange,
@@ -57,6 +60,25 @@ export function PlayerMarker({
   const [menuPosition, setMenuPosition] = useState({ x: 0, y: 0 });
   const longPressTimeout = React.useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const [markerSize, setMarkerSize] = useState(size || initialSize);
+  const translate = React.useRef(new Animated.ValueXY({ x: position.x, y: position.y })).current;
+
+  // While the finger is down the marker must track it 1:1; any other position
+  // change (undo/redo/reset/drill load/Together cancel) glides so the eye can
+  // follow where each piece went.
+  const { x: targetX, y: targetY } = position;
+  useEffect(() => {
+    if (isLifted) {
+      translate.stopAnimation();
+      translate.setValue({ x: targetX, y: targetY });
+    } else {
+      Animated.timing(translate, {
+        toValue: { x: targetX, y: targetY },
+        duration: 260,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: true,
+      }).start();
+    }
+  }, [isLifted, targetX, targetY, translate]);
 
   // Update internal markerSize when size prop changes
   useEffect(() => {
@@ -95,18 +117,18 @@ export function PlayerMarker({
 
   return (
     <>
-      <View
+      <Animated.View
         style={[
           styles.marker,
           {
             backgroundColor: color,
-            borderColor: markerRingColor(color),
+            borderColor: linked ? palette.accent : markerRingColor(color),
+            borderWidth: linked ? 3 : 2.5,
             width: markerSize,
             height: markerSize,
             borderRadius: markerSize / 2,
             transform: [
-              { translateX: position.x },
-              { translateY: position.y },
+              ...translate.getTranslateTransform(),
               { scale: isLifted ? 1.12 : 1 },
             ],
             shadowOpacity: isLifted ? 0.6 : 0.35,
@@ -185,7 +207,7 @@ export function PlayerMarker({
             ]}
           />
         )}
-      </View>
+      </Animated.View>
 
       <Modal
         visible={showCustomizationMenu}

--- a/components/PlayerMarker.tsx
+++ b/components/PlayerMarker.tsx
@@ -23,6 +23,10 @@ interface PlayerMarkerProps {
   iconType?: 'icon' | 'text' | 'photo';
   /** Amber ring: this piece is part of the armed Together step. */
   linked?: boolean;
+  /** Duration of the glide between steps (ms); user-tunable in Customize. */
+  glideMs?: number;
+  /** Playback: the piece ignores touches entirely. */
+  locked?: boolean;
   onPositionChange?: (newPosition: { x: number; y: number }) => void;
   onPositionStart?: (newPosition: { x: number; y: number }) => void;
   onPositionChangeComplete?: () => void;
@@ -46,6 +50,8 @@ export function PlayerMarker({
   icon = 'account',
   iconType = 'icon',
   linked = false,
+  glideMs = 260,
+  locked = false,
   onPositionChange,
   onPositionStart,
   onPositionChangeComplete,
@@ -73,12 +79,12 @@ export function PlayerMarker({
     } else {
       Animated.timing(translate, {
         toValue: { x: targetX, y: targetY },
-        duration: 260,
+        duration: glideMs,
         easing: Easing.out(Easing.cubic),
         useNativeDriver: true,
       }).start();
     }
-  }, [isLifted, targetX, targetY, translate]);
+  }, [glideMs, isLifted, targetX, targetY, translate]);
 
   // Update internal markerSize when size prop changes
   useEffect(() => {
@@ -137,8 +143,8 @@ export function PlayerMarker({
             opacity: 1,
           },
         ]}
-        onStartShouldSetResponder={() => true}
-        onMoveShouldSetResponder={() => true}
+        onStartShouldSetResponder={() => !locked}
+        onMoveShouldSetResponder={() => !locked}
         onResponderGrant={(event: GestureResponderEvent) => {
           const touch = event.nativeEvent;
           setTouchOffset({

--- a/components/SettingsPanel.tsx
+++ b/components/SettingsPanel.tsx
@@ -242,9 +242,24 @@ interface SettingsPanelProps {
   onClose: () => void;
   isDoubles: boolean;
   onGameModeChange: (isDoubles: boolean) => void;
+  /** Glide duration between steps (ms). */
+  stepAnimationMs: number;
+  onStepAnimationChange: (ms: number) => void;
 }
 
-export function SettingsPanel({ isVisible, onClose, isDoubles, onGameModeChange }: SettingsPanelProps) {
+// Speed slider bounds: left end = slow (800ms glide), right end = fast (80ms).
+// The slider position is the inverse of the duration: pos = 880 - ms.
+const GLIDE_SLOWEST = 800;
+const GLIDE_FASTEST = 80;
+
+export function SettingsPanel({
+  isVisible,
+  onClose,
+  isDoubles,
+  onGameModeChange,
+  stepAnimationMs,
+  onStepAnimationChange,
+}: SettingsPanelProps) {
   const { customizations, updateMarkerCustomization, resetCustomizations } = useMarkerCustomization();
 
   // Switching mode reseeds the court, so ignore taps on the already-active option.
@@ -281,7 +296,7 @@ export function SettingsPanel({ isVisible, onClose, isDoubles, onGameModeChange 
           <View style={styles.header}>
             <View>
               <Text style={styles.headerTitle}>Customize</Text>
-              <Text style={styles.headerSubtitle}>Game mode, marker colors, icons and sizes</Text>
+              <Text style={styles.headerSubtitle}>Game mode, step speed, marker colors and icons</Text>
             </View>
             <TouchableOpacity onPress={onClose} hitSlop={8} style={styles.closeButton}>
               <MaterialCommunityIcons name="close" size={18} color={palette.textPrimary} />
@@ -321,6 +336,27 @@ export function SettingsPanel({ isVisible, onClose, isDoubles, onGameModeChange 
                   Doubles
                 </Text>
               </TouchableOpacity>
+            </View>
+
+            <Text style={styles.sectionLabel}>Step speed</Text>
+            <View style={styles.speedCard}>
+              <MaterialCommunityIcons name="turtle" size={19} color={palette.textSecondary} />
+              <View style={styles.speedSlider}>
+                <AppSlider
+                  minimumValue={GLIDE_FASTEST}
+                  maximumValue={GLIDE_SLOWEST}
+                  value={GLIDE_SLOWEST + GLIDE_FASTEST - stepAnimationMs}
+                  onValueChange={(v) =>
+                    onStepAnimationChange(Math.round(GLIDE_SLOWEST + GLIDE_FASTEST - v))
+                  }
+                  trackColor="rgba(255, 255, 255, 0.16)"
+                  trackHeight={5}
+                  filledColor="rgba(255, 201, 77, 0.55)"
+                  thumbColor={palette.accent}
+                  thumbSize={16}
+                />
+              </View>
+              <MaterialCommunityIcons name="rabbit" size={19} color={palette.textSecondary} />
             </View>
 
             <Text style={styles.sectionLabel}>Team 1</Text>
@@ -479,6 +515,21 @@ const styles = StyleSheet.create({
   modeOptionTextActive: {
     ...sora('700'),
     color: palette.onAccent,
+  },
+  speedCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+    backgroundColor: palette.card,
+    borderWidth: 1,
+    borderColor: palette.cardBorder,
+    borderRadius: radii.md,
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    marginBottom: 6,
+  },
+  speedSlider: {
+    flex: 1,
   },
   rowCard: {
     flexDirection: 'row',

--- a/hooks/useCourtPositions.ts
+++ b/hooks/useCourtPositions.ts
@@ -21,6 +21,17 @@ interface PositionState {
   };
 }
 
+const hasMoved = (a: PlayerPosition, b: PlayerPosition) => a.x !== b.x || a.y !== b.y;
+
+function statesDiffer(a: PositionState, b: PositionState): boolean {
+  return (
+    hasMoved(a.shuttle, b.shuttle) ||
+    (['team1', 'team2'] as const).some((team) =>
+      a.players[team].some((pos, i) => hasMoved(pos, b.players[team][i]))
+    )
+  );
+}
+
 export function useCourtPositions(courtDimensions: CourtDimensions) {
   const [isDoubles, setIsDoubles] = useState(true);
   const [showPlayerTrails, setShowPlayerTrails] = useState(true);
@@ -28,7 +39,9 @@ export function useCourtPositions(courtDimensions: CourtDimensions) {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [positionHistory, setPositionHistory] = useState<PositionState[]>([]);
   const [tempPosition, setTempPosition] = useState<PositionState | null>(null);
-  const [positions, setPositions] = useState<PositionState | null>(null);
+  // Together: while armed, drag commits are deferred — every move accumulates
+  // in tempPosition and saving pushes them as one history step.
+  const [isTogether, setIsTogether] = useState(false);
   // Initialize state with ghost markers at the same positions as players and shuttle
   useEffect(() => {
     const initialPlayers = getInitialPositions(isDoubles, courtDimensions);
@@ -47,35 +60,29 @@ export function useCourtPositions(courtDimensions: CourtDimensions) {
 
   const updatePosition = useCallback((
     newState: Pick<PositionState, 'players' | 'shuttle'>,
-    currentState: PositionState,
+    base: PositionState,
+    committed: PositionState,
     team?: 'team1' | 'team2',
     index?: number,
     isShuttle: boolean = false,
     isStart: boolean = false
   ) => {
     if (isStart) {
-      // Create ghost positions based on current positions, but only update
-      // the specific marker that's starting to move
+      // Refresh only the dragged piece's ghost, seeding it from the committed
+      // state so re-dragging a piece mid-Together keeps its step-start ghost.
       const ghostPositions = {
-        team1: [...currentState.ghostPositions.team1],
-        team2: [...currentState.ghostPositions.team2],
-        shuttle: currentState.ghostPositions.shuttle,
+        team1: [...base.ghostPositions.team1],
+        team2: [...base.ghostPositions.team2],
+        shuttle: base.ghostPositions.shuttle,
       };
 
       if (team && typeof index === 'number') {
-        // Only update the ghost position for the specific player being moved
-        ghostPositions[team][index] = currentState.players[team][index];
+        ghostPositions[team][index] = committed.players[team][index];
       } else if (isShuttle) {
-        // Only update shuttle ghost position if shuttle is being moved
-        ghostPositions.shuttle = currentState.shuttle;
+        ghostPositions.shuttle = committed.shuttle;
       }
 
       setTempPosition({
-        ...newState,
-        ghostPositions,
-      });
-
-      setPositions({
         ...newState,
         ghostPositions,
       });
@@ -83,7 +90,7 @@ export function useCourtPositions(courtDimensions: CourtDimensions) {
       // During drag, maintain existing ghost positions
       setTempPosition(prevTemp => ({
         ...newState,
-        ghostPositions: prevTemp?.ghostPositions || currentState.ghostPositions,
+        ghostPositions: prevTemp?.ghostPositions || base.ghostPositions,
       }));
     }
   }, []);
@@ -94,46 +101,66 @@ export function useCourtPositions(courtDimensions: CourtDimensions) {
     newPosition: PlayerPosition,
     isStart: boolean = false
   ) => {
-    const currentState = positionHistory[currentIndex];
+    const committed = positionHistory[currentIndex];
+    // Base on the in-progress temp state so moving a second piece (Together)
+    // doesn't clobber the first piece's uncommitted move.
+    const base = tempPosition ?? committed;
     const newPlayers = {
-      ...currentState.players,
-      [team]: currentState.players[team].map((pos, i) => 
+      ...base.players,
+      [team]: base.players[team].map((pos, i) =>
         i === index ? newPosition : pos
       ),
     };
-    
-    updatePosition({ 
-      players: newPlayers, 
-      shuttle: currentState.shuttle 
-    }, currentState, team, index, false, isStart);
-  }, [currentIndex, positionHistory, updatePosition]);
+
+    updatePosition({
+      players: newPlayers,
+      shuttle: base.shuttle
+    }, base, committed, team, index, false, isStart);
+  }, [currentIndex, positionHistory, tempPosition, updatePosition]);
 
   const updateShuttlePosition = useCallback((
     newPosition: PlayerPosition,
     isStart: boolean = false
   ) => {
-    const currentState = positionHistory[currentIndex];
-    updatePosition({ 
-      players: currentState.players, 
-      shuttle: newPosition 
-    }, currentState, undefined, undefined, true, isStart);
-  }, [currentIndex, positionHistory, updatePosition]);
+    const committed = positionHistory[currentIndex];
+    const base = tempPosition ?? committed;
+    updatePosition({
+      players: base.players,
+      shuttle: newPosition
+    }, base, committed, undefined, undefined, true, isStart);
+  }, [currentIndex, positionHistory, tempPosition, updatePosition]);
+
+  const commitTemp = useCallback(() => {
+    if (!tempPosition) return;
+    // Skip no-op commits: a tap without a drag must not add a history step.
+    if (statesDiffer(tempPosition, positionHistory[currentIndex])) {
+      setPositionHistory(prev => [...prev.slice(0, currentIndex + 1), tempPosition]);
+      setCurrentIndex(prev => prev + 1);
+    }
+    setTempPosition(null);
+  }, [currentIndex, positionHistory, tempPosition]);
 
   const handlePositionChangeComplete = useCallback(() => {
-    if (!tempPosition) return;
+    if (isTogether) return; // armed: keep accumulating until saved
+    commitTemp();
+  }, [commitTemp, isTogether]);
 
-    // When drag completes, update the position history with the new positions
-    // and their corresponding ghost positions
-    setPositionHistory(prev => {
-      const newHistory = prev.slice(0, currentIndex + 1);
-      return [...newHistory, {
-        ...tempPosition,
-        ghostPositions: tempPosition.ghostPositions,
-      }];
-    });
-    setCurrentIndex(prev => prev + 1);
+  // Arm Together, or — when already armed — save the accumulated moves as
+  // one history step.
+  const toggleTogether = useCallback(() => {
+    if (!isTogether) {
+      setIsTogether(true);
+      return;
+    }
+    setIsTogether(false);
+    commitTemp();
+  }, [commitTemp, isTogether]);
+
+  // Discard the armed step; markers glide back to their committed spots.
+  const cancelTogether = useCallback(() => {
+    setIsTogether(false);
     setTempPosition(null);
-  }, [currentIndex, tempPosition]);
+  }, []);
 
   // Reset ghost markers when resetting positions
   const resetPositions = useCallback(() => {
@@ -150,6 +177,8 @@ export function useCourtPositions(courtDimensions: CourtDimensions) {
     };
     setPositionHistory([initialState]);
     setCurrentIndex(0);
+    setTempPosition(null);
+    setIsTogether(false);
   }, [isDoubles, courtDimensions]);
 
   const toggleGameMode = useCallback((value: boolean) => {
@@ -167,6 +196,8 @@ export function useCourtPositions(courtDimensions: CourtDimensions) {
     };
     setPositionHistory([initialState]);
     setCurrentIndex(0);
+    setTempPosition(null);
+    setIsTogether(false);
   }, [courtDimensions]);
 
   const undo = useCallback(() => {
@@ -206,7 +237,7 @@ export function useCourtPositions(courtDimensions: CourtDimensions) {
     setPositionHistory(steps);
     setCurrentIndex(0);
     setTempPosition(null);
-    setPositions(null);
+    setIsTogether(false);
   }, [isDoubles]);
 
   const loadNormalizedSteps = useCallback((
@@ -217,6 +248,17 @@ export function useCourtPositions(courtDimensions: CourtDimensions) {
     loadSteps(courtSteps, nextIsDoubles);
   }, [courtDimensions, isDoubles, loadSteps]);
 
+  // Which pieces have uncommitted moves in the armed Together step (drives
+  // the amber rings and the dock badge count).
+  const committedState = positionHistory[currentIndex];
+  const togetherMoved = isTogether && tempPosition && committedState
+    ? {
+        team1: tempPosition.players.team1.map((pos, i) => hasMoved(pos, committedState.players.team1[i])),
+        team2: tempPosition.players.team2.map((pos, i) => hasMoved(pos, committedState.players.team2[i])),
+        shuttle: hasMoved(tempPosition.shuttle, committedState.shuttle),
+      }
+    : null;
+
   return {
     isDoubles,
     playerPositions: tempPosition?.players || positionHistory[currentIndex]?.players || getInitialPositions(isDoubles, courtDimensions),
@@ -224,6 +266,10 @@ export function useCourtPositions(courtDimensions: CourtDimensions) {
     updatePlayerPosition,
     updateShuttlePosition,
     handlePositionChangeComplete,
+    isTogether,
+    toggleTogether,
+    cancelTogether,
+    togetherMoved,
     toggleGameMode,
     resetPositions,
     undo,

--- a/hooks/useCourtPositions.ts
+++ b/hooks/useCourtPositions.ts
@@ -42,6 +42,9 @@ export function useCourtPositions(courtDimensions: CourtDimensions) {
   // Together: while armed, drag commits are deferred — every move accumulates
   // in tempPosition and saving pushes them as one history step.
   const [isTogether, setIsTogether] = useState(false);
+  // Playback: a loaded drill starts locked — walk/play the steps; Fork exits
+  // to editing at the current step.
+  const [isPlayback, setIsPlayback] = useState(false);
   // Initialize state with ghost markers at the same positions as players and shuttle
   useEffect(() => {
     const initialPlayers = getInitialPositions(isDoubles, courtDimensions);
@@ -179,7 +182,38 @@ export function useCourtPositions(courtDimensions: CourtDimensions) {
     setCurrentIndex(0);
     setTempPosition(null);
     setIsTogether(false);
+    setIsPlayback(false);
   }, [isDoubles, courtDimensions]);
+
+  // Collapse the stack to a single step holding the current positions — for
+  // setting up a starting formation, then recording steps from it.
+  const clearSteps = useCallback(() => {
+    const current = positionHistory[currentIndex];
+    if (!current) return;
+    setPositionHistory([{
+      players: current.players,
+      shuttle: current.shuttle,
+      ghostPositions: {
+        team1: [...current.players.team1],
+        team2: [...current.players.team2],
+        shuttle: current.shuttle,
+      },
+    }]);
+    setCurrentIndex(0);
+    setTempPosition(null);
+    setIsTogether(false);
+  }, [currentIndex, positionHistory]);
+
+  // Fork: unlock a loaded drill for editing at the current step. The next
+  // committed drag naturally truncates the steps ahead.
+  const exitPlayback = useCallback(() => {
+    setIsPlayback(false);
+  }, []);
+
+  // Jump back to the first step (autoplay loop restart).
+  const goToStart = useCallback(() => {
+    setCurrentIndex(0);
+  }, []);
 
   const toggleGameMode = useCallback((value: boolean) => {
     setIsDoubles(value);
@@ -198,6 +232,7 @@ export function useCourtPositions(courtDimensions: CourtDimensions) {
     setCurrentIndex(0);
     setTempPosition(null);
     setIsTogether(false);
+    setIsPlayback(false);
   }, [courtDimensions]);
 
   const undo = useCallback(() => {
@@ -238,6 +273,7 @@ export function useCourtPositions(courtDimensions: CourtDimensions) {
     setCurrentIndex(0);
     setTempPosition(null);
     setIsTogether(false);
+    setIsPlayback(true);
   }, [isDoubles]);
 
   const loadNormalizedSteps = useCallback((
@@ -270,8 +306,12 @@ export function useCourtPositions(courtDimensions: CourtDimensions) {
     toggleTogether,
     cancelTogether,
     togetherMoved,
+    isPlayback,
+    exitPlayback,
+    goToStart,
     toggleGameMode,
     resetPositions,
+    clearSteps,
     undo,
     redo,
     canUndo: currentIndex > 0,


### PR DESCRIPTION
## What's in here

Four court features, built on top of the Drill Vault work in main:

### Together — move multiple pieces as one step
Arming **Together** (dock) defers drag commits: moves accumulate on the live board (amber ring + count badge on linked pieces, banner explains the mode), tapping Together again saves them as **one** history step, **Cancel** discards and returns pieces to their last committed spots. Steps remain full-board snapshots, so drill save/load and share links needed no format changes.

### Glide transitions
Markers are now Animated.Views: 1:1 finger tracking while dragging, and a glide for any other position change (undo/redo/reset/drill load/Together cancel) so it's easy to see where each piece moved. A Together step plays back with all its pieces gliding simultaneously.

### Step speed slider + contextual Reset/Clear
Customize gains a **Step speed** slider (turtle→rabbit, 80–800 ms) driving both the glide and autoplay pacing. The first dock button is contextual: **Reset** (back to defaults) when the stack is empty, **Clear** when steps exist — Clear wipes the stack but keeps current positions, for staging a starting formation.

### Drill playback
Loading or importing a drill (saved, shared, or from the Vault) enters a locked playback mode: pieces ignore touches, the header pill shows the drill name + step i/n with a progress bar and toggles an info card (description for Vault drills, plus steps / mode / together-steps / saved-date chips), a dismissible banner explains the lock, and the dock swaps to **Fork / Back / Next / Play**. Play autoplays, holds ~3 beats at the end, then loops; Fork unlocks editing at the current step (next committed drag truncates the steps ahead).

### Also
- Fixed a latent bug via the shared commit path: tapping a marker without dragging no longer adds a duplicate history step.
- Vault drill loads route through the same playback path as saved drills, so their description/category/difficulty surface in the info card.

## Verification
Exercised end-to-end on an AVD per AGENTS.md (drag/tap/undo/redo glide, Together arm→link→save→replay, cancel, clear vs reset, speed slider effect, saved-drill playback incl. autoplay loop and fork, persistence round-trip). `tsc`, `expo lint`, and all 61 jest tests pass on the rebased tree.

## Notes for review
- Undo/Redo are disabled while Together is armed (Save or Cancel first) — deliberate, to avoid silently discarding an uncommitted group.
- Saving a drill while armed snapshots committed steps only.
- Playback loop is always-on (no loop toggle); the mockup's loop badge on Play was dropped as non-actionable.