### PR TITLE
Record critical-user-flow videos on every PR

### DIFF
--- a/.github/workflows/pr-apk.yml
+++ b/.github/workflows/pr-apk.yml
@@ -73,3 +73,55 @@ jobs:
           name: apk-pr${{ github.event.number }}
           path: android/app/build/outputs/apk/release/app-release.apk
           retention-days: 14
+
+  # Records a video of each critical user flow (.maestro/*.yaml) on an
+  # emulator and uploads them as an artifact — download from the run page.
+  # ponytail: no AVD snapshot caching; add the two-pass cache from the
+  # android-emulator-runner README if the ~5 min boot starts to hurt.
+  cuf-videos:
+    needs: apk
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Download APK Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: apk-pr${{ github.event.number }}
+
+      - name: Setup Java JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Install Maestro
+        run: |
+          curl -fsSL https://get.maestro.mobile.dev | bash
+          echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
+
+      - name: Record critical user flows
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          arch: x86_64
+          profile: pixel_6
+          disable-animations: true
+          # the action runs `script:` line-by-line under sh — loops must live
+          # in a real script file
+          script: bash ./scripts/record-cufs.sh
+
+      - name: Upload CUF Videos
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cuf-videos-pr${{ github.event.number }}
+          path: cuf-videos/
+          retention-days: 14

--- a/.maestro/01-court-steps.yaml
+++ b/.maestro/01-court-steps.yaml
@@ -1,0 +1,27 @@
+# CUF: move markers, step counter, undo/redo/reset.
+# App defaults: doubles mode, trails on. Swipe coordinates target the default
+# doubles positions (top-left player 25%/30% of court, shuttle 54%/59%); the
+# Step assertions fail if a drag misses, so a layout change shows up here.
+appId: com.haritabhgupta.badmintoncourtsimulator
+---
+- launchApp:
+    clearState: true
+- assertVisible: "Doubles.*Step 1"
+- swipe:
+    start: 30%, 35%
+    end: 45%, 20%
+    duration: 800
+- assertVisible: "Doubles.*Step 2"
+- swipe:
+    start: 53%, 56%
+    end: 70%, 45%
+    duration: 800
+- assertVisible: "Doubles.*Step 3"
+- tapOn: "Undo"
+- assertVisible: "Doubles.*Step 2"
+- tapOn: "Redo"
+- assertVisible: "Doubles.*Step 3"
+# with steps built the first dock slot is "Clear" (wipes the stack,
+# keeps positions); it only reads "Reset" while the board is pristine
+- tapOn: "Clear"
+- assertVisible: "Doubles.*Step 1"

--- a/.maestro/02-singles-mode.yaml
+++ b/.maestro/02-singles-mode.yaml
@@ -1,0 +1,14 @@
+# CUF: open settings, switch to singles (doubles is the default),
+# court re-seeds with two players.
+appId: com.haritabhgupta.badmintoncourtsimulator
+---
+- launchApp:
+    clearState: true
+- assertVisible: "Doubles.*Step 1"
+- tapOn: "Customize"
+- assertVisible: "Game mode"
+- tapOn: "Singles"
+# the mode switch re-seeds the court and races the Back key, so close
+# via the labeled X instead (Back sometimes exits the app — seen locally)
+- tapOn: "Close settings"
+- assertVisible: "Singles.*Step 1"

--- a/.maestro/03-save-drill.yaml
+++ b/.maestro/03-save-drill.yaml
@@ -1,0 +1,27 @@
+# CUF: build a step, save it as a named drill, see it in My Drills.
+appId: com.haritabhgupta.badmintoncourtsimulator
+---
+- launchApp:
+    clearState: true
+# settle: the court re-seeds once the real layout is measured right after
+# launch; swiping before that eats the gesture (flake seen locally)
+- assertVisible: "Doubles.*Step 1"
+- swipe:
+    start: 30%, 35%
+    end: 45%, 20%
+    duration: 800
+- assertVisible: "Doubles.*Step 2"
+- tapOn: "Drills"
+- assertVisible: "My Drills"
+- tapOn: "Save current steps"
+- assertVisible: "Save drill"
+- tapOn: "Name"
+- inputText: "CI Smoke Drill"
+# no hideKeyboard: on CI's soft-keyboard image it closes the dialog like
+# Back; with adjustPan the panned dialog keeps Save tappable anyway
+- tapOn: "Save"
+# dismiss the "has been saved" confirmation alert before checking the list
+- assertVisible: ".*has been saved.*"
+- tapOn: "OK"
+- assertVisible: "CI Smoke Drill"
+- tapOn: "Close drills"

--- a/.maestro/04-vault-drill.yaml
+++ b/.maestro/04-vault-drill.yaml
@@ -1,0 +1,33 @@
+# CUF: browse the Drill Vault, hit the paywall on a premium drill,
+# load a free singles drill and step through it (trails are on by default).
+appId: com.haritabhgupta.badmintoncourtsimulator
+---
+- launchApp:
+    clearState: true
+- tapOn: "Drills"
+- tapOn: "Drill Vault"
+- assertVisible: "Four-Corner Shadow"
+- assertVisible: "FREE"
+# en-dashes in the name matched loosely; first premium drill in the vault
+- scrollUntilVisible:
+    element:
+      text: "Clear.Drop.Net Squeeze"
+    direction: DOWN
+- tapOn: "Clear.Drop.Net Squeeze"
+- assertVisible: "Drill Vault Pro"
+- assertVisible: "Restore purchases"
+- tapOn: "Close paywall"
+- scrollUntilVisible:
+    element:
+      text: "Four-Corner Shadow"
+    direction: UP
+- tapOn: "Four-Corner Shadow"
+# loading a drill enters locked playback: banner + "name · 1/9" header,
+# and the dock swaps to Fork/Back/Next/Play
+- assertVisible: "Drill loaded.*"
+- assertVisible: "1/9"
+- repeat:
+    times: 6
+    commands:
+      - tapOn: "Next"
+- assertVisible: "7/9"

--- a/components/BadmintonCourt.tsx
+++ b/components/BadmintonCourt.tsx
@@ -496,6 +496,7 @@ export default function BadmintonCourt() {
           <Pressable
             onPress={() => setDrillHubTab('vault')}
             hitSlop={8}
+            accessibilityLabel="Drill Vault"
             style={({ pressed }) => [styles.headerAction, pressed && styles.glassPressed]}
           >
             <MaterialCommunityIcons name="treasure-chest" size={20} color={palette.accent} />
@@ -508,6 +509,7 @@ export default function BadmintonCourt() {
           <Pressable
             onPress={() => setIsMenuVisible(true)}
             hitSlop={8}
+            accessibilityLabel="Customize"
             style={({ pressed }) => [styles.headerAction, pressed && styles.glassPressed]}
           >
             <MaterialCommunityIcons name="tune-variant" size={20} color={palette.textPrimary} />

--- a/components/DrillHubPanel.tsx
+++ b/components/DrillHubPanel.tsx
@@ -257,7 +257,12 @@ export function DrillHubPanel({
                     : 'Tactical patterns ready to load onto the court'}
                 </Text>
               </View>
-              <TouchableOpacity onPress={onClose} hitSlop={8} style={styles.closeButton}>
+              <TouchableOpacity
+                onPress={onClose}
+                hitSlop={8}
+                accessibilityLabel="Close drills"
+                style={styles.closeButton}
+              >
                 <MaterialCommunityIcons name="close" size={18} color={palette.textPrimary} />
               </TouchableOpacity>
             </View>
@@ -531,6 +536,7 @@ export function DrillHubPanel({
                 <TouchableOpacity
                   onPress={() => setPaywallVisible(false)}
                   hitSlop={8}
+                  accessibilityLabel="Close paywall"
                   style={styles.closeButton}
                 >
                   <MaterialCommunityIcons name="close" size={18} color={palette.textPrimary} />

--- a/components/SettingsPanel.tsx
+++ b/components/SettingsPanel.tsx
@@ -298,7 +298,12 @@ export function SettingsPanel({
               <Text style={styles.headerTitle}>Customize</Text>
               <Text style={styles.headerSubtitle}>Game mode, step speed, marker colors and icons</Text>
             </View>
-            <TouchableOpacity onPress={onClose} hitSlop={8} style={styles.closeButton}>
+            <TouchableOpacity
+              onPress={onClose}
+              hitSlop={8}
+              accessibilityLabel="Close settings"
+              style={styles.closeButton}
+            >
               <MaterialCommunityIcons name="close" size={18} color={palette.textPrimary} />
             </TouchableOpacity>
           </View>

--- a/scripts/record-cufs.sh
+++ b/scripts/record-cufs.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Runs each Maestro CUF flow with adb screenrecord wrapped around it and
+# pulls the mp4s into cuf-videos/. Called by the cuf-videos job in pr-apk.yml
+# as a single line because android-emulator-runner executes `script:` input
+# line-by-line under sh, which breaks multi-line loops.
+set -u
+
+adb install app-release.apk
+mkdir -p cuf-videos
+rc=0
+for flow in .maestro/*.yaml; do
+  name=$(basename "$flow" .yaml)
+  adb shell "screenrecord --bit-rate 4000000 --time-limit 170 /sdcard/$name.mp4" &
+  maestro test "$flow" || rc=1
+  adb shell pkill -INT screenrecord || true
+  sleep 3
+  adb pull "/sdcard/$name.mp4" "cuf-videos/$name.mp4" || true
+done
+exit $rc


### PR DESCRIPTION
## What

Every PR now produces short screen-recordings of the app's critical user flows, reviewable straight from the workflow run — download the `cuf-videos-pr<N>` artifact and watch.

- **`cuf-videos` job in `pr-apk.yml`**: boots an API 34 emulator (KVM-accelerated, animations off), installs the APK built by the existing `apk` job, runs each Maestro flow in `.maestro/` wrapped in `adb screenrecord`, and uploads the mp4s (14-day retention). Videos upload even when a flow fails, so a red run still shows what went wrong on screen. A failing flow fails the job.
- **Four flows** (one video each):
  1. `01-court-steps` — drag a player + the shuttle, step counter, undo/redo/reset
  2. `02-singles-mode` — settings panel, doubles → singles, court re-seeds
  3. `03-save-drill` — build a step, save it as a named drill, confirm it lands in My Drills
  4. `04-vault-drill` — vault browsing, paywall on a premium drill, load a free drill and step through it
- **Accessibility labels** on five icon-only buttons (header Drill Vault/Customize, the three sheet/paywall close X's). Maestro uses them as stable selectors; screen readers get named buttons instead of unlabeled icons.

## Notes for review

- Flow selectors are visible text / a11y labels only — no testIDs added to app code.
- Flows encode behavior verified on a real emulator: doubles + trails-on defaults, "Step 1" as the pristine state, a settle-assert before the first coordinate swipe (the court re-seeds on first layout), and labeled close buttons instead of the Back key (Back races the mode-switch re-seed and can background the app).
- Expect roughly +10–15 min per PR, dominated by emulator boot. AVD snapshot caching (two-pass pattern from the android-emulator-runner README) is the known lever if that starts to hurt.
- Billing/RevenueCat flows are deliberately out of scope: no Play services on the CI image; the app falls back to free tier, which these flows cover.

## How it was verified

Full suite run locally three times against the exact CI loop (same screenrecord wrapper, release APK on an emulator), including once against this branch rebased on current `main` — 4/4 flows green, all mp4s valid (finalized moov atom, playable). `tsc --noEmit` and eslint clean.