### PR TITLE
feat(court): tilt-to-3D world view with rally playback

### DIFF
--- a/.maestro/05-together-step.yaml
+++ b/.maestro/05-together-step.yaml
@@ -1,0 +1,29 @@
+# CUF: arm Together, drag two pieces, save them as one history step.
+# While armed the step counter must not advance; the closing Undo proves
+# both moves rewind as a single step.
+appId: com.haritabhgupta.badmintoncourtsimulator
+---
+- launchApp:
+    clearState: true
+# settle: the court re-seeds once the real layout is measured (see 03)
+- assertVisible: "Doubles.*Step 1"
+- tapOn: "Together"
+- assertVisible: "Together is on.*"
+# armed: the first dock slot flips to Cancel
+- assertVisible: "Cancel"
+- swipe:
+    start: 30%, 35%
+    end: 45%, 22%
+    duration: 800
+# deferred: a piece moved but no step was committed
+- assertVisible: "Doubles.*Step 1"
+- swipe:
+    start: 30%, 75%
+    end: 45%, 62%
+    duration: 800
+- assertVisible: "Doubles.*Step 1"
+# second tap saves the accumulated moves as one step
+- tapOn: "Together"
+- assertVisible: "Doubles.*Step 2"
+- tapOn: "Undo"
+- assertVisible: "Doubles.*Step 1"

--- a/.maestro/06-tilt-3d-drill.yaml
+++ b/.maestro/06-tilt-3d-drill.yaml
@@ -1,0 +1,37 @@
+# CUF: load a vault drill, tilt into the 3D world view, start playback and
+# pan-rotate the camera while the rally is flying.
+appId: com.haritabhgupta.badmintoncourtsimulator
+---
+- launchApp:
+    clearState: true
+- tapOn: "Drills"
+- tapOn: "Drill Vault"
+- assertVisible: "Four-Corner Shadow"
+- tapOn: "Four-Corner Shadow"
+- assertVisible: "Drill loaded.*"
+- assertVisible: "1/9"
+- tapOn: "3D"
+# the hint chip only renders once the court has tilted in
+- assertVisible: "drag to rotate and tilt"
+- tapOn: "Play"
+# 3D playback advances through the steps on its own
+- extendedWaitUntil:
+    visible: "3/9"
+    timeout: 15000
+# pan-rotate mid-rally: yaw right, then tilt down and yaw back
+- swipe:
+    start: 25%, 45%
+    end: 75%, 48%
+    duration: 900
+- swipe:
+    start: 70%, 40%
+    end: 35%, 65%
+    duration: 900
+# still playing after the orbit; the counter keeps climbing (wraps at 9)
+- assertVisible: "Pause"
+- extendedWaitUntil:
+    visible: "6/9"
+    timeout: 20000
+# round-trip back to the flat court: playback lock is still on
+- tapOn: "2D"
+- assertVisible: "Drill loaded.*"

--- a/components/BadmintonCourt.tsx
+++ b/components/BadmintonCourt.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { View, StyleSheet, Dimensions, Text, Pressable, LayoutChangeEvent } from 'react-native';
 import { appAlert } from '../utils/appAlert';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -7,6 +7,8 @@ import * as Linking from 'expo-linking';
 import { PlayerMarker } from './PlayerMarker';
 import { IconButton } from './IconButton';
 import { CourtSvg } from './CourtSvg';
+import { Court3DView, Step3D } from './Court3DView';
+import { courtPointFromScreen } from '../utils/court3d';
 import { useCourtPositions } from '../hooks/useCourtPositions';
 import { STEP_SET_LIMIT, useStepSets } from '../hooks/useStepSets';
 import { PositionTrail } from './PositionTrail';
@@ -116,12 +118,17 @@ export default function BadmintonCourt() {
   };
 
   // The painted lines sit inset from the edges; the green mat fills the screen.
-  const linesRect = {
-    x: LINES_SIDE_INSET,
-    y: area.y + LINES_GAP,
-    width: area.width - LINES_SIDE_INSET * 2,
-    height: area.height - LINES_GAP * 2,
-  };
+  // Stable identity: the 3D layer keys its projection and step memos off it.
+  const { y: areaY, width: areaW, height: areaH } = area;
+  const linesRect = useMemo(
+    () => ({
+      x: LINES_SIDE_INSET,
+      y: areaY + LINES_GAP,
+      width: areaW - LINES_SIDE_INSET * 2,
+      height: areaH - LINES_GAP * 2,
+    }),
+    [areaY, areaW, areaH]
+  );
   const courtDimensions = { width: screenWidth, height: screenHeight, linesRect };
 
   const onRootLayout = (event: LayoutChangeEvent) => {
@@ -190,6 +197,7 @@ export default function BadmintonCourt() {
     clearSteps,
     undo,
     redo,
+    goToStep,
     canUndo,
     canRedo,
     showPlayerTrails,
@@ -205,6 +213,87 @@ export default function BadmintonCourt() {
   const togetherCount = togetherMoved
     ? [...togetherMoved.team1, ...togetherMoved.team2, togetherMoved.shuttle].filter(Boolean).length
     : 0;
+
+  // ── Tilt-to-3D ─────────────────────────────────────────────────────────
+  // `tilt` is the 2D↔3D blend b; toggling tweens it, and the 3D layer stays
+  // mounted until it lands back on 0 so the court morphs instead of popping.
+  const [is3D, setIs3D] = useState(false);
+  const [isPlaying3D, setIsPlaying3D] = useState(false);
+  const [tilt, setTilt] = useState(0);
+  const tiltRef = useRef(0);
+  const tiltRaf = useRef<number | null>(null);
+
+  const animateTilt = useCallback((target: number) => {
+    if (tiltRaf.current != null) cancelAnimationFrame(tiltRaf.current);
+    const from = tiltRef.current;
+    const t0 = performance.now();
+    const DUR = 430;
+    const frame = (now: number) => {
+      let u = Math.min(1, (now - t0) / DUR);
+      u = u < 0.5 ? 2 * u * u : 1 - Math.pow(-2 * u + 2, 2) / 2;
+      const v = from + (target - from) * u;
+      tiltRef.current = v;
+      setTilt(v);
+      if (u < 1) tiltRaf.current = requestAnimationFrame(frame);
+    };
+    tiltRaf.current = requestAnimationFrame(frame);
+  }, []);
+
+  useEffect(() => () => {
+    if (tiltRaf.current != null) cancelAnimationFrame(tiltRaf.current);
+  }, []);
+
+  const setMode3D = (to3D: boolean) => {
+    if (to3D === is3D) return;
+    setIs3D(to3D);
+    // Only one playback clock at a time: 3D flights vs the 2D step interval.
+    if (to3D) setIsPlaying(false);
+    else setIsPlaying3D(false);
+    animateTilt(to3D ? 1 : 0);
+  };
+
+  const show3D = is3D || tilt > 0.001;
+
+  // Current history rendered as court-unit pins (positions are view top-left).
+  const steps3d: Step3D[] = useMemo(() => {
+    const teamIds: ('P1' | 'P2' | 'P3' | 'P4')[][] = isDoubles
+      ? [['P1', 'P2'], ['P3', 'P4']]
+      : [['P1'], ['P3']];
+    const pin = (pos: { x: number; y: number }, id: 'P1' | 'P2' | 'P3' | 'P4') => {
+      const c = customizations[id];
+      return {
+        ...courtPointFromScreen(pos.x + c.size / 2, pos.y + c.size / 2, linesRect),
+        color: c.color,
+        size: c.size,
+      };
+    };
+    const shuttleHalf = customizations.Shuttle.size / 2;
+    return getStepsSnapshot().map((step) => ({
+      players: [
+        ...step.players.team1.map((pos, i) => pin(pos, teamIds[0][i])),
+        ...step.players.team2.map((pos, i) => pin(pos, teamIds[1][i])),
+      ],
+      shuttle: courtPointFromScreen(
+        step.shuttle.x + shuttleHalf,
+        step.shuttle.y + shuttleHalf,
+        linesRect
+      ),
+    }));
+  }, [customizations, getStepsSnapshot, isDoubles, linesRect]);
+
+  const advance3D = useCallback(() => {
+    if (canRedo) redo();
+    else goToStep(0); // loop the rally like the prototype
+  }, [canRedo, redo, goToStep]);
+
+  const step3DIndex = stepCount - 1;
+  const back3D = () => goToStep(step3DIndex === 0 ? totalSteps - 1 : step3DIndex - 1);
+  const next3D = () => goToStep((step3DIndex + 1) % totalSteps);
+
+  // A freshly loaded/reset board can drop below 2 steps mid-playback.
+  useEffect(() => {
+    if (totalSteps < 2 && isPlaying3D) setIsPlaying3D(false);
+  }, [totalSteps, isPlaying3D]);
 
   // Once the real court area is measured, re-seed the default positions —
   // but only while the board is pristine (nothing moved, no history).
@@ -370,12 +459,31 @@ export default function BadmintonCourt() {
   return (
     <View style={styles.container} onLayout={onRootLayout}>
       {/* Full-bleed court */}
-      <View style={StyleSheet.absoluteFill}>
-        <CourtSvg width={screenWidth} height={screenHeight} linesRect={linesRect} />
-      </View>
+      {!show3D && (
+        <View style={StyleSheet.absoluteFill}>
+          <CourtSvg width={screenWidth} height={screenHeight} linesRect={linesRect} />
+        </View>
+      )}
+
+      {/* Tilted world: replaces the flat court and markers while tilt > 0 */}
+      {show3D && (
+        <Court3DView
+          width={screenWidth}
+          height={screenHeight}
+          linesRect={linesRect}
+          b={tilt}
+          steps={steps3d}
+          playing={isPlaying3D}
+          onAdvance={advance3D}
+          showPlayerTrails={showPlayerTrails}
+          showShuttleTrail={showShuttleTrail}
+          shuttleSize={customizations.Shuttle.size}
+          hintBottom={dockBottom + estimatedDockHeight + 12}
+        />
+      )}
 
       {/* Trails + markers (coordinates are screen coordinates) */}
-      {showPlayerTrails && playerPositions.team1.map((pos, index) => (
+      {!show3D && showPlayerTrails && playerPositions.team1.map((pos, index) => (
         ghostPositions?.team1[index] && (
           <PositionTrail
             key={`trail-team1-${index}`}
@@ -385,7 +493,7 @@ export default function BadmintonCourt() {
           />
         )
       ))}
-      {showPlayerTrails && playerPositions.team2.map((pos, index) => (
+      {!show3D && showPlayerTrails && playerPositions.team2.map((pos, index) => (
         ghostPositions?.team2[index] && (
           <PositionTrail
             key={`trail-team2-${index}`}
@@ -395,7 +503,7 @@ export default function BadmintonCourt() {
           />
         )
       ))}
-      {showShuttleTrail && shuttlePosition && ghostPositions?.shuttle && (
+      {!show3D && showShuttleTrail && shuttlePosition && ghostPositions?.shuttle && (
         <PositionTrail
           currentPosition={shuttlePosition}
           ghostPosition={ghostPositions.shuttle}
@@ -403,7 +511,7 @@ export default function BadmintonCourt() {
         />
       )}
 
-      {playerPositions.team1.map((pos, index) => (
+      {!show3D && playerPositions.team1.map((pos, index) => (
         <PlayerMarker
           key={`team1-${index}`}
           position={pos}
@@ -423,7 +531,7 @@ export default function BadmintonCourt() {
           onIconChange={(icon) => updateMarkerCustomization(index === 0 ? 'P1' : 'P2', { icon })}
         />
       ))}
-      {playerPositions.team2.map((pos, index) => (
+      {!show3D && playerPositions.team2.map((pos, index) => (
         <PlayerMarker
           key={`team2-${index}`}
           position={pos}
@@ -444,25 +552,28 @@ export default function BadmintonCourt() {
         />
       ))}
 
-      <PlayerMarker
-        position={shuttlePosition}
-        color={customizations.Shuttle.color}
-        size={customizations.Shuttle.size}
-        icon={customizations.Shuttle.icon}
-        iconType={customizations.Shuttle.iconType}
-        linked={!!togetherMoved?.shuttle}
-        glideMs={stepAnimationMs}
-        locked={isPlayback}
-        onPositionChange={updateShuttlePosition}
-        onPositionStart={(newPos) => updateShuttlePosition(newPos, true)}
-        onPositionChangeComplete={handlePositionChangeComplete}
-        onColorChange={(color) => updateMarkerCustomization('Shuttle', { color })}
-        onSizeChange={(size) => updateMarkerCustomization('Shuttle', { size })}
-        onIconChange={(icon) => updateMarkerCustomization('Shuttle', { icon })}
-      />
+      {!show3D && (
+        <PlayerMarker
+          position={shuttlePosition}
+          color={customizations.Shuttle.color}
+          size={customizations.Shuttle.size}
+          icon={customizations.Shuttle.icon}
+          iconType={customizations.Shuttle.iconType}
+          linked={!!togetherMoved?.shuttle}
+          glideMs={stepAnimationMs}
+          locked={isPlayback}
+          onPositionChange={updateShuttlePosition}
+          onPositionStart={(newPos) => updateShuttlePosition(newPos, true)}
+          onPositionChangeComplete={handlePositionChangeComplete}
+          onColorChange={(color) => updateMarkerCustomization('Shuttle', { color })}
+          onSizeChange={(size) => updateMarkerCustomization('Shuttle', { size })}
+          onIconChange={(icon) => updateMarkerCustomization('Shuttle', { icon })}
+        />
+      )}
 
-      {/* Floating header: mode/drill pill + customize button (stays Settings
-          in playback too; the banner ✕ is the only dismiss control) */}
+      {/* Floating header: mode/drill pill + 2D/3D switch + customize button
+          (stays Settings in playback too; the banner ✕ is the only dismiss
+          control) */}
       <View style={[styles.header, { marginTop: headerTop }]} pointerEvents="box-none">
         {isPlayback && loadedDrill ? (
           <Pressable style={styles.namePill} onPress={() => setInfoOpen((open) => !open)}>
@@ -475,7 +586,9 @@ export default function BadmintonCourt() {
               size={14}
               color={palette.textSecondary}
             />
-            <Text style={[styles.namePillCount, isPlaying && { color: palette.accent }]}>
+            <Text
+              style={[styles.namePillCount, (isPlaying || isPlaying3D) && { color: palette.accent }]}
+            >
               {stepCount}/{totalSteps}
             </Text>
             <View style={styles.namePillTrack}>
@@ -487,12 +600,27 @@ export default function BadmintonCourt() {
         ) : (
           <View style={styles.modePill}>
             <MaterialCommunityIcons name="badminton" size={18} color={palette.textPrimary} />
-            <Text style={styles.modePillLabel}>
+            <Text style={styles.modePillLabel} numberOfLines={1}>
               {isDoubles ? 'Doubles' : 'Singles'} · Step {stepCount}
+              {is3D ? `/${totalSteps}` : ''}
             </Text>
           </View>
         )}
         <View style={styles.headerActions}>
+          <View style={styles.modeSegment}>
+            <Pressable
+              onPress={() => setMode3D(false)}
+              style={[styles.segmentBtn, !is3D && styles.segmentBtnActive]}
+            >
+              <Text style={[styles.segmentText, !is3D && styles.segmentTextActive]}>2D</Text>
+            </Pressable>
+            <Pressable
+              onPress={() => setMode3D(true)}
+              style={[styles.segmentBtn, is3D && styles.segmentBtnActive]}
+            >
+              <Text style={[styles.segmentText, is3D && styles.segmentTextActive]}>3D</Text>
+            </Pressable>
+          </View>
           <Pressable
             onPress={() => setDrillHubTab('vault')}
             hitSlop={8}
@@ -517,8 +645,9 @@ export default function BadmintonCourt() {
         </View>
       </View>
 
-      {/* Playback lock banner (✕ dismisses just the banner) */}
-      {isPlayback && !lockBannerDismissed && !infoOpen && (
+      {/* Playback lock banner (✕ dismisses just the banner; 2D only — in 3D
+          nothing is draggable anyway) */}
+      {!show3D && isPlayback && !lockBannerDismissed && !infoOpen && (
         <View
           style={[styles.lockBanner, { top: headerTop + HEADER_HEIGHT + spacing.md }]}
           pointerEvents="box-none"
@@ -570,7 +699,7 @@ export default function BadmintonCourt() {
       )}
 
       {/* Armed-Together banner (visual only; never blocks drags underneath) */}
-      {isTogether && (
+      {!show3D && isTogether && (
         <View
           style={[styles.togetherBanner, { top: headerTop + HEADER_HEIGHT + spacing.md }]}
           pointerEvents="none"
@@ -588,9 +717,31 @@ export default function BadmintonCourt() {
       {/* Court area spacer between header and dock — its measured rect hosts the lines */}
       <View style={styles.courtArea} pointerEvents="none" onLayout={onCourtAreaLayout} />
 
-      {/* Floating bottom dock */}
+      {/* Floating bottom dock: edit controls in 2D, playback controls in 3D */}
       <View style={[styles.dock, { marginBottom: dockBottom }]}>
-        {isPlayback ? (
+        {is3D ? (
+          <>
+            <IconButton
+              icon="skip-previous"
+              label="Back"
+              onPress={back3D}
+              disabled={totalSteps < 2}
+            />
+            <IconButton
+              icon={isPlaying3D ? 'pause' : 'play'}
+              label={isPlaying3D ? 'Pause' : 'Play'}
+              onPress={() => setIsPlaying3D((prev) => !prev)}
+              active
+              disabled={totalSteps < 2}
+            />
+            <IconButton
+              icon="skip-next"
+              label="Next"
+              onPress={next3D}
+              disabled={totalSteps < 2}
+            />
+          </>
+        ) : isPlayback ? (
           <>
             <IconButton icon="source-fork" label="Fork" onPress={handleFork} />
             <IconButton icon="step-backward" label="Back" onPress={stepBack} disabled={!canUndo} />
@@ -691,6 +842,7 @@ const styles = StyleSheet.create({
   },
   modePill: {
     height: HEADER_HEIGHT,
+    flexShrink: 1,
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing.sm,
@@ -700,6 +852,32 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: palette.glassPillBorder,
     ...shadows.card,
+  },
+  modeSegment: {
+    height: HEADER_HEIGHT,
+    flexDirection: 'row',
+    borderRadius: radii.pill,
+    backgroundColor: palette.glassPill,
+    borderWidth: 1,
+    borderColor: palette.glassPillBorder,
+    overflow: 'hidden',
+    ...shadows.card,
+  },
+  segmentBtn: {
+    paddingHorizontal: 11,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  segmentBtnActive: {
+    backgroundColor: palette.accent,
+  },
+  segmentText: {
+    ...sora('700'),
+    fontSize: 11,
+    color: palette.textSecondary,
+  },
+  segmentTextActive: {
+    color: palette.onAccent,
   },
   modePillLabel: {
     ...sora('600'),
@@ -744,7 +922,9 @@ const styles = StyleSheet.create({
   // Drill name pill: like the mode pill, plus a step progress bar at the bottom.
   namePill: {
     height: HEADER_HEIGHT + 2,
-    maxWidth: '78%',
+    // Shrinks below its content (name truncates) so the 2D/3D switch and the
+    // header icons never get pushed off-screen; RN flexShrink defaults to 0.
+    flexShrink: 1,
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing.sm,

--- a/components/BadmintonCourt.tsx
+++ b/components/BadmintonCourt.tsx
@@ -659,8 +659,8 @@ export default function BadmintonCourt() {
               Walk the steps with Back / Next, or press Play
             </Text>
             <Text style={styles.lockBannerBody}>
-              <Text style={styles.lockBannerAccent}>Fork</Text> copies the drill so you can edit
-              from this step
+              <Text style={styles.lockBannerAccent}>Fork</Text> exits playback at any stage so
+              you can edit from that step
             </Text>
           </View>
           <Pressable
@@ -688,6 +688,10 @@ export default function BadmintonCourt() {
           {loadedDrill.description ? (
             <Text style={styles.infoCardBody}>{loadedDrill.description}</Text>
           ) : null}
+          <Text style={styles.infoCardBody}>
+            <Text style={styles.lockBannerAccent}>Fork</Text> exits drill playback at any stage
+            and unlocks the pieces for editing.
+          </Text>
           <View style={styles.chipRow}>
             {loadedDrill.chips.map((chip) => (
               <View key={chip} style={styles.chip}>

--- a/components/Court3DView.tsx
+++ b/components/Court3DView.tsx
@@ -1,0 +1,467 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { GestureResponderEvent, StyleSheet, Text, View } from 'react-native';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import Svg, {
+  Circle,
+  Defs,
+  Ellipse,
+  G,
+  Line,
+  LinearGradient,
+  Path,
+  Polygon,
+  Rect,
+  Stop,
+} from 'react-native-svg';
+import { LINE_UNITS, LinesRect } from './CourtSvg';
+import { palette, radii, sora } from '../constants/theme';
+import {
+  arcPath,
+  courtLinesPath,
+  CourtPoint,
+  COURT_H,
+  COURT_W,
+  makeProjector,
+  NET_POST_H,
+  NET_X0,
+  NET_X1,
+  NET_Y,
+  PHI_MAX,
+  Projected,
+  REST_STEP_MS,
+  Shot,
+  shotBetween,
+  shotPos,
+  THETA_DEFAULT,
+  THETA_MAX,
+  THETA_MIN,
+  ZOOM_MAX,
+  ZOOM_MIN,
+} from '../utils/court3d';
+
+export interface Pin3D extends CourtPoint {
+  color: string;
+  size: number;
+}
+
+export interface Step3D {
+  players: Pin3D[];
+  shuttle: CourtPoint;
+}
+
+interface Court3DViewProps {
+  width: number;
+  height: number;
+  linesRect: LinesRect;
+  /** Tilt blend, tweened by the parent: 0 = flat, 1 = full 3D. */
+  b: number;
+  /** History up to and including the current step; the last entry is shown. */
+  steps: Step3D[];
+  playing: boolean;
+  /** Called when the current flight (plus landing hold) finishes. */
+  onAdvance: () => void;
+  showPlayerTrails: boolean;
+  showShuttleTrail: boolean;
+  shuttleSize: number;
+  /** Distance from the bottom for the gesture hint chip (clears the dock). */
+  hintBottom: number;
+}
+
+// Flight time fraction: hold on the landed shuttle for a beat (matches the
+// design prototype) before the step advances.
+const HOLD_END = 1.32;
+
+const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
+
+// Marker glyphs traced from the design prototype (24-unit viewBox).
+const PERSON_BODY = 'M4.5 20.5c1.4-4 4.2-6 7.5-6s6.1 2 7.5 6Z';
+const SHUTTLE_STROKES = 'M12 14.5 7 4.5m5 10V4m0 10.5L17 4.5';
+
+export function Court3DView({
+  width,
+  height,
+  linesRect,
+  b,
+  steps,
+  playing,
+  onAdvance,
+  showPlayerTrails,
+  showShuttleTrail,
+  shuttleSize,
+  hintBottom,
+}: Court3DViewProps) {
+  const stepIndex = steps.length - 1;
+  const [cam, setCam] = useState({ thetaDeg: THETA_DEFAULT, phiDeg: 0, zoom: 1 });
+  // tp starts landed (1) so entering 3D shows the board exactly where 2D left
+  // it; it rewinds to 0 (replaying the flight in) only when the step changes.
+  const [tp, setTp] = useState(1);
+  const tpRef = useRef(1);
+  const shownStep = useRef(stepIndex);
+
+  useEffect(() => {
+    if (shownStep.current !== stepIndex) {
+      shownStep.current = stepIndex;
+      tpRef.current = 0;
+      setTp(0);
+    }
+  }, [stepIndex]);
+
+  const shot: Shot | null = useMemo(() => {
+    if (stepIndex < 1) return null;
+    return shotBetween(steps[stepIndex - 1].shuttle, steps[stepIndex].shuttle);
+  }, [steps, stepIndex]);
+
+  const onAdvanceRef = useRef(onAdvance);
+  onAdvanceRef.current = onAdvance;
+
+  useEffect(() => {
+    if (!playing) return;
+    const dur = shot ? shot.dur : REST_STEP_MS;
+    let raf = 0;
+    let last: number | null = null;
+    let advanced = false;
+    const tick = (now: number) => {
+      if (last != null) {
+        const next = tpRef.current + Math.min(50, now - last) / dur;
+        if (next >= HOLD_END) {
+          advanced = true;
+          onAdvanceRef.current();
+        } else {
+          tpRef.current = next;
+          setTp(next);
+        }
+      }
+      last = now;
+      if (!advanced) raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [playing, stepIndex, shot]);
+
+  // Orbit drag / pinch zoom. Raw responder state lives in a ref; deltas apply
+  // to cam state per move event.
+  const touchRef = useRef<{ single: [number, number] | null; pinchD: number | null }>({
+    single: null,
+    pinchD: null,
+  });
+
+  const readTouches = (e: GestureResponderEvent) => {
+    const touches = e.nativeEvent.touches;
+    const t = touchRef.current;
+    if (touches.length >= 2) {
+      const d = Math.hypot(
+        touches[0].pageX - touches[1].pageX,
+        touches[0].pageY - touches[1].pageY
+      );
+      if (t.pinchD != null && t.pinchD > 4) {
+        const r = d / t.pinchD;
+        setCam((c) => ({ ...c, zoom: clamp(c.zoom * r, ZOOM_MIN, ZOOM_MAX) }));
+      }
+      t.pinchD = d;
+      t.single = null;
+    } else if (touches.length === 1) {
+      const px = touches[0].pageX;
+      const py = touches[0].pageY;
+      if (t.single) {
+        const dx = px - t.single[0];
+        const dy = py - t.single[1];
+        setCam((c) => ({
+          ...c,
+          thetaDeg: clamp(c.thetaDeg - dy * 0.22, THETA_MIN, THETA_MAX),
+          phiDeg: clamp(c.phiDeg + dx * 0.12, -PHI_MAX, PHI_MAX),
+        }));
+      }
+      t.single = [px, py];
+      t.pinchD = null;
+    }
+  };
+
+  const clearTouches = () => {
+    touchRef.current.single = null;
+    touchRef.current.pinchD = null;
+  };
+
+  if (!steps.length) return null;
+
+  const project = makeProjector(linesRect, { ...cam, b });
+  const lineWidth = Math.max(1.5, LINE_UNITS * (linesRect.width / COURT_W));
+  const tc = Math.min(1, tp);
+
+  // Scene geometry
+  const corner = (x: number, z: number) => project(x, z, 0);
+  const floorPts = [corner(0, 0), corner(COURT_W, 0), corner(COURT_W, COURT_H), corner(0, COURT_H)]
+    .map((p) => `${p[0].toFixed(1)},${p[1].toFixed(1)}`)
+    .join(' ');
+  const linesD = courtLinesPath(project);
+
+  const nb1 = project(NET_X0, NET_Y, 0);
+  const nb2 = project(NET_X1, NET_Y, 0);
+  const nt1 = project(NET_X0, NET_Y, NET_POST_H);
+  const nt2 = project(NET_X1, NET_Y, NET_POST_H);
+  const seg = (a: Projected, c: Projected) =>
+    `M${a[0].toFixed(1)} ${a[1].toFixed(1)} L${c[0].toFixed(1)} ${c[1].toFixed(1)}`;
+  const netPts = [nb1, nb2, nt2, nt1].map((p) => `${p[0].toFixed(1)},${p[1].toFixed(1)}`).join(' ');
+
+  // Ghost arcs of the flights already played
+  let ghostD = '';
+  if (showShuttleTrail) {
+    for (let k = 1; k < stepIndex; k++) {
+      const g = shotBetween(steps[k - 1].shuttle, steps[k].shuttle);
+      if (g) ghostD += arcPath(project, g, 0, 1, 16) + ' ';
+    }
+  }
+
+  const cur = steps[stepIndex];
+  const prev = stepIndex > 0 ? steps[stepIndex - 1] : null;
+
+  // Shuttle: mid-flight along the shot, or resting on the current spot
+  const shuttleCourt = shot ? shotPos(shot, tc) : [cur.shuttle.x, cur.shuttle.z, 0];
+  const sp3 = project(shuttleCourt[0], shuttleCourt[1], shuttleCourt[2]);
+  const gp = project(shuttleCourt[0], shuttleCourt[1], 0);
+  const land = shot ? project(shot.p1.x, shot.p1.z, 0) : null;
+  const sw = shuttleSize * clamp(sp3[2], 0.8, 1.3);
+  const squash = 1 - 0.58 * b; // ground ellipses foreshorten with the tilt
+
+  // Player pins glide between the previous and current step with the flight
+  const pins = cur.players.map((p, i) => {
+    const from = prev?.players[i] ?? p;
+    const t = prev ? tc : 1;
+    const x = from.x + (p.x - from.x) * t;
+    const z = from.z + (p.z - from.z) * t;
+    const f = project(x, z, 0);
+    const w = p.size * clamp(f[2], 0.8, 1.3);
+    const stemH = Math.max(0, 13 * b * f[2]);
+    // Flat: disc centered on its court spot; tilted: disc stands on a stem.
+    const discCy = f[1] - stemH - w / 2 + (w / 2 + 3) * (1 - b);
+    const glyph = w * 0.44;
+    return { key: i, color: p.color, fx: f[0], fy: f[1], w, stemH, discCy, glyph };
+  });
+
+  const playerTrails =
+    showPlayerTrails && prev
+      ? cur.players
+          .map((p, i) => {
+            const from = prev.players[i];
+            if (!from || (from.x === p.x && from.z === p.z)) return null;
+            const a = project(from.x, from.z, 0);
+            const c = project(p.x, p.z, 0);
+            return { key: i, x1: a[0], y1: a[1], x2: c[0], y2: c[1] };
+          })
+          .filter((v): v is NonNullable<typeof v> => v !== null)
+      : [];
+
+  const shuttleGlyph = sw * 0.46;
+
+  return (
+    <View style={StyleSheet.absoluteFill}>
+      <Svg width={width} height={height} pointerEvents="none">
+        <Defs>
+          <LinearGradient id="court3dBg" x1="0" y1="0" x2="0" y2="1">
+            <Stop offset="0" stopColor={palette.courtTop} />
+            <Stop offset="0.55" stopColor={palette.courtMid} />
+            <Stop offset="1" stopColor={palette.courtBottom} />
+          </LinearGradient>
+          <LinearGradient id="fog3d" x1="0" y1="0" x2="0" y2="1">
+            <Stop offset="0" stopColor={palette.courtTop} stopOpacity={1} />
+            <Stop offset="1" stopColor={palette.courtTop} stopOpacity={0} />
+          </LinearGradient>
+        </Defs>
+
+        <Rect x={0} y={0} width={width} height={height} fill="url(#court3dBg)" />
+        <Polygon points={floorPts} fill="rgba(0,0,0,0.08)" />
+        <Path d={linesD} stroke={palette.courtLine} strokeWidth={lineWidth} strokeLinecap="round" fill="none" />
+        <Path
+          d={seg(nb1, nb2)}
+          stroke="#FFFFFF"
+          strokeOpacity={0.85}
+          strokeWidth={3.2}
+          strokeDasharray="2 8"
+          strokeLinecap="round"
+          fill="none"
+        />
+        {b > 0.02 && (
+          <Rect
+            x={0}
+            y={0}
+            width={width}
+            height={linesRect.y + linesRect.height * 0.27}
+            fill="url(#fog3d)"
+            opacity={0.85 * b}
+          />
+        )}
+        {!!ghostD && (
+          <Path d={ghostD} stroke={palette.accent} strokeOpacity={0.22} strokeWidth={3} strokeLinecap="round" fill="none" />
+        )}
+        <Polygon points={netPts} fill="rgba(255,255,255,0.14)" />
+        <Path d={seg(nt1, nt2)} stroke="#FFFFFF" strokeOpacity={0.95} strokeWidth={2.6} strokeLinecap="round" fill="none" />
+        <Path
+          d={`${seg(nb1, nt1)} ${seg(nb2, nt2)}`}
+          stroke="#FFFFFF"
+          strokeOpacity={0.7}
+          strokeWidth={3}
+          strokeLinecap="round"
+          fill="none"
+        />
+
+        {playerTrails.map((t) => (
+          <Line
+            key={`ptrail-${t.key}`}
+            x1={t.x1}
+            y1={t.y1}
+            x2={t.x2}
+            y2={t.y2}
+            stroke="#FFFFFF"
+            strokeOpacity={0.6}
+            strokeWidth={2.5}
+            strokeDasharray="1 8"
+            strokeLinecap="round"
+          />
+        ))}
+
+        {shot && showShuttleTrail && land && (
+          <>
+            <Ellipse
+              cx={land[0]}
+              cy={land[1]}
+              rx={11 * land[2]}
+              ry={11 * land[2] * squash}
+              fill="none"
+              stroke={palette.accent}
+              strokeWidth={2.5}
+              strokeDasharray="2 5"
+            />
+            <Path
+              d={arcPath(project, shot, 0, 1)}
+              stroke={palette.accent}
+              strokeOpacity={0.32}
+              strokeWidth={3}
+              strokeDasharray="3 9"
+              strokeLinecap="round"
+              fill="none"
+            />
+            <Path
+              d={arcPath(project, shot, 0, Math.max(0.001, tc))}
+              stroke={palette.accent}
+              strokeWidth={3.5}
+              strokeLinecap="round"
+              fill="none"
+            />
+            <Line
+              x1={sp3[0]}
+              y1={sp3[1] + sw * 0.4}
+              x2={gp[0]}
+              y2={gp[1] - 1}
+              stroke="#FFFFFF"
+              strokeOpacity={0.9}
+              strokeWidth={2.5}
+              strokeDasharray="1 7"
+              strokeLinecap="round"
+            />
+          </>
+        )}
+
+        {/* Ground contact shadow under the shuttle */}
+        <Ellipse cx={gp[0]} cy={gp[1]} rx={13 * gp[2]} ry={13 * gp[2] * squash} fill="rgba(0,0,0,0.34)" />
+
+        {/* Player pins: floor shadow, stem, disc with person glyph */}
+        {pins.map((p) => (
+          <G key={`pin-${p.key}`}>
+            <Ellipse
+              cx={p.fx}
+              cy={p.fy}
+              rx={(p.w * 0.74) / 2}
+              ry={(p.w * 0.28) / 2}
+              fill="rgba(0,0,0,0.33)"
+              opacity={0.25 + 0.75 * b}
+            />
+            {p.stemH > 0.5 && (
+              <Line
+                x1={p.fx}
+                y1={p.fy}
+                x2={p.fx}
+                y2={p.fy - p.stemH}
+                stroke="rgba(255,255,255,0.8)"
+                strokeWidth={3}
+                strokeLinecap="round"
+              />
+            )}
+            <Circle
+              cx={p.fx}
+              cy={p.discCy}
+              r={p.w / 2}
+              fill={p.color}
+              stroke="rgba(255,255,255,0.95)"
+              strokeWidth={2.5}
+            />
+            <G
+              transform={`translate(${p.fx - p.glyph / 2}, ${p.discCy - p.glyph / 2}) scale(${p.glyph / 24})`}
+            >
+              <Circle cx={12} cy={8.2} r={4} fill="#FFFFFF" />
+              <Path d={PERSON_BODY} fill="#FFFFFF" />
+            </G>
+          </G>
+        ))}
+
+        {/* Shuttle chip */}
+        <Circle cx={sp3[0]} cy={sp3[1]} r={sw / 2} fill="#FFFFFF" />
+        <G
+          transform={`translate(${sp3[0] - shuttleGlyph / 2}, ${sp3[1] - shuttleGlyph / 2}) scale(${shuttleGlyph / 24})`}
+        >
+          <Path
+            d={SHUTTLE_STROKES}
+            stroke={palette.shuttleGlyph}
+            strokeWidth={2.2}
+            strokeLinecap="round"
+            fill="none"
+          />
+          <Circle cx={12} cy={18.4} r={3} fill={palette.shuttleGlyph} />
+        </G>
+      </Svg>
+
+      {/* Orbit / pinch surface (dock and header sit above and win touches) */}
+      <View
+        style={StyleSheet.absoluteFill}
+        onStartShouldSetResponder={() => true}
+        onMoveShouldSetResponder={() => true}
+        onResponderGrant={readTouches}
+        onResponderMove={readTouches}
+        onResponderRelease={clearTouches}
+        onResponderTerminate={clearTouches}
+      />
+
+      {b > 0.5 && (
+        <View pointerEvents="none" style={[styles.hintWrap, { bottom: hintBottom }]}>
+          <View style={styles.hintPill}>
+            <MaterialCommunityIcons name="rotate-3d" size={12} color="rgba(255,255,255,0.85)" />
+            <Text style={styles.hintText}>drag to orbit · pinch to zoom</Text>
+          </View>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  hintWrap: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    alignItems: 'center',
+  },
+  hintPill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 12,
+    paddingVertical: 7,
+    borderRadius: radii.pill,
+    backgroundColor: 'rgba(6, 26, 18, 0.6)',
+    borderWidth: 1,
+    borderColor: palette.glassPillBorder,
+  },
+  hintText: {
+    ...sora('600'),
+    fontSize: 9,
+    color: 'rgba(255, 255, 255, 0.75)',
+  },
+});

--- a/components/Court3DView.tsx
+++ b/components/Court3DView.tsx
@@ -89,7 +89,9 @@ export function Court3DView({
   hintBottom,
 }: Court3DViewProps) {
   const stepIndex = steps.length - 1;
-  const [cam, setCam] = useState({ thetaDeg: THETA_DEFAULT, phiDeg: 0 });
+  // phiRaw is the unfiltered drag accumulator; the displayed yaw applies a
+  // soft detent at straight-on (see phiDeg below).
+  const [cam, setCam] = useState({ thetaDeg: THETA_DEFAULT, phiRaw: 0 });
   // tp starts landed (1) so entering 3D shows the board exactly where 2D left
   // it; it rewinds to 0 (replaying the flight in) only when the step changes.
   const [tp, setTp] = useState(1);
@@ -154,7 +156,7 @@ export function Court3DView({
       const dy = py - prev[1];
       setCam((c) => ({
         thetaDeg: clamp(c.thetaDeg - dy * 0.22, THETA_MIN, THETA_MAX),
-        phiDeg: clamp(c.phiDeg - dx * 0.12, -PHI_MAX, PHI_MAX),
+        phiRaw: clamp(c.phiRaw - dx * 0.12, -PHI_MAX, PHI_MAX),
       }));
     }
     touchRef.current = [px, py];
@@ -166,7 +168,16 @@ export function Court3DView({
 
   if (!steps.length) return null;
 
-  const project = makeProjector(linesRect, { ...cam, zoom: 1, b });
+  // Soft detent at straight-on: yaw holds at 0 through a small dead zone
+  // (~20dp of drag) and eases back in past it, still reaching the full range.
+  const SNAP_DEG = 2.5;
+  const phiMag = Math.abs(cam.phiRaw);
+  const phiDeg =
+    phiMag <= SNAP_DEG
+      ? 0
+      : ((phiMag - SNAP_DEG) / (PHI_MAX - SNAP_DEG)) * PHI_MAX * Math.sign(cam.phiRaw);
+
+  const project = makeProjector(linesRect, { thetaDeg: cam.thetaDeg, phiDeg, zoom: 1, b });
   const lineWidth = Math.max(1.5, LINE_UNITS * (linesRect.width / COURT_W));
   const tc = Math.min(1, tp);
 

--- a/components/Court3DView.tsx
+++ b/components/Court3DView.tsx
@@ -35,8 +35,6 @@ import {
   THETA_DEFAULT,
   THETA_MAX,
   THETA_MIN,
-  ZOOM_MAX,
-  ZOOM_MIN,
 } from '../utils/court3d';
 
 export interface Pin3D extends CourtPoint {
@@ -91,7 +89,7 @@ export function Court3DView({
   hintBottom,
 }: Court3DViewProps) {
   const stepIndex = steps.length - 1;
-  const [cam, setCam] = useState({ thetaDeg: THETA_DEFAULT, phiDeg: 0, zoom: 1 });
+  const [cam, setCam] = useState({ thetaDeg: THETA_DEFAULT, phiDeg: 0 });
   // tp starts landed (1) so entering 3D shows the board exactly where 2D left
   // it; it rewinds to 0 (replaying the flight in) only when the step changes.
   const [tp, setTp] = useState(1);
@@ -138,52 +136,37 @@ export function Court3DView({
     return () => cancelAnimationFrame(raf);
   }, [playing, stepIndex, shot]);
 
-  // Orbit drag / pinch zoom. Raw responder state lives in a ref; deltas apply
-  // to cam state per move event.
-  const touchRef = useRef<{ single: [number, number] | null; pinchD: number | null }>({
-    single: null,
-    pinchD: null,
-  });
+  // One-finger orbit; deltas apply to cam state per move event. Yaw is
+  // negated so the near court — the part under the finger — follows the drag.
+  const touchRef = useRef<[number, number] | null>(null);
 
   const readTouches = (e: GestureResponderEvent) => {
     const touches = e.nativeEvent.touches;
-    const t = touchRef.current;
-    if (touches.length >= 2) {
-      const d = Math.hypot(
-        touches[0].pageX - touches[1].pageX,
-        touches[0].pageY - touches[1].pageY
-      );
-      if (t.pinchD != null && t.pinchD > 4) {
-        const r = d / t.pinchD;
-        setCam((c) => ({ ...c, zoom: clamp(c.zoom * r, ZOOM_MIN, ZOOM_MAX) }));
-      }
-      t.pinchD = d;
-      t.single = null;
-    } else if (touches.length === 1) {
-      const px = touches[0].pageX;
-      const py = touches[0].pageY;
-      if (t.single) {
-        const dx = px - t.single[0];
-        const dy = py - t.single[1];
-        setCam((c) => ({
-          ...c,
-          thetaDeg: clamp(c.thetaDeg - dy * 0.22, THETA_MIN, THETA_MAX),
-          phiDeg: clamp(c.phiDeg + dx * 0.12, -PHI_MAX, PHI_MAX),
-        }));
-      }
-      t.single = [px, py];
-      t.pinchD = null;
+    if (touches.length !== 1) {
+      touchRef.current = null; // extra fingers park the gesture
+      return;
     }
+    const px = touches[0].pageX;
+    const py = touches[0].pageY;
+    const prev = touchRef.current;
+    if (prev) {
+      const dx = px - prev[0];
+      const dy = py - prev[1];
+      setCam((c) => ({
+        thetaDeg: clamp(c.thetaDeg - dy * 0.22, THETA_MIN, THETA_MAX),
+        phiDeg: clamp(c.phiDeg - dx * 0.12, -PHI_MAX, PHI_MAX),
+      }));
+    }
+    touchRef.current = [px, py];
   };
 
   const clearTouches = () => {
-    touchRef.current.single = null;
-    touchRef.current.pinchD = null;
+    touchRef.current = null;
   };
 
   if (!steps.length) return null;
 
-  const project = makeProjector(linesRect, { ...cam, b });
+  const project = makeProjector(linesRect, { ...cam, zoom: 1, b });
   const lineWidth = Math.max(1.5, LINE_UNITS * (linesRect.width / COURT_W));
   const tc = Math.min(1, tp);
 
@@ -433,7 +416,7 @@ export function Court3DView({
         <View pointerEvents="none" style={[styles.hintWrap, { bottom: hintBottom }]}>
           <View style={styles.hintPill}>
             <MaterialCommunityIcons name="rotate-3d" size={12} color="rgba(255,255,255,0.85)" />
-            <Text style={styles.hintText}>drag to orbit · pinch to zoom</Text>
+            <Text style={styles.hintText}>drag to rotate and tilt</Text>
           </View>
         </View>
       )}

--- a/components/Court3DView.tsx
+++ b/components/Court3DView.tsx
@@ -196,15 +196,6 @@ export function Court3DView({
     `M${a[0].toFixed(1)} ${a[1].toFixed(1)} L${c[0].toFixed(1)} ${c[1].toFixed(1)}`;
   const netPts = [nb1, nb2, nt2, nt1].map((p) => `${p[0].toFixed(1)},${p[1].toFixed(1)}`).join(' ');
 
-  // Ghost arcs of the flights already played
-  let ghostD = '';
-  if (showShuttleTrail) {
-    for (let k = 1; k < stepIndex; k++) {
-      const g = shotBetween(steps[k - 1].shuttle, steps[k].shuttle);
-      if (g) ghostD += arcPath(project, g, 0, 1, 16) + ' ';
-    }
-  }
-
   const cur = steps[stepIndex];
   const prev = stepIndex > 0 ? steps[stepIndex - 1] : null;
 
@@ -282,9 +273,6 @@ export function Court3DView({
             fill="url(#fog3d)"
             opacity={0.85 * b}
           />
-        )}
-        {!!ghostD && (
-          <Path d={ghostD} stroke={palette.accent} strokeOpacity={0.22} strokeWidth={3} strokeLinecap="round" fill="none" />
         )}
         <Polygon points={netPts} fill="rgba(255,255,255,0.14)" />
         <Path d={seg(nt1, nt2)} stroke="#FFFFFF" strokeOpacity={0.95} strokeWidth={2.6} strokeLinecap="round" fill="none" />

--- a/components/CourtSvg.tsx
+++ b/components/CourtSvg.tsx
@@ -24,14 +24,16 @@ interface CourtSvgProps {
 }
 
 // Real BWF proportions, 1 unit = 1 cm, full doubles court 610 x 1340.
-const COURT_W = 610;
-const COURT_H = 1340;
-const SINGLES_X = [46, 564];
-const LONG_SERVICE_Y = [76, 1264];
-const SHORT_SERVICE_Y = [472, 868];
-const CENTER_X = 305;
-const NET_Y = 670;
-const LINE_UNITS = 4; // real 40mm painted lines
+// Shared with the 3D projection (utils/court3d.ts).
+export const COURT_W = 610;
+export const COURT_H = 1340;
+export const SINGLES_X = [46, 564];
+export const LONG_SERVICE_Y = [76, 1264];
+export const SHORT_SERVICE_Y = [472, 868];
+export const CENTER_X = 305;
+export const NET_Y = 670;
+export const LINE_UNITS = 4; // real 40mm painted lines
+export const NET_OVERHANG_UNITS = 20; // posts sit past the doubles sidelines
 
 /**
  * Full-bleed "Match Point" court: green gradient edge-to-edge, white 80%
@@ -49,7 +51,7 @@ function CourtSvgComponent({ width, height, linesRect }: CourtSvgProps) {
   };
 
   const netY = Y(NET_Y);
-  const netOverhang = 20 * sx;
+  const netOverhang = NET_OVERHANG_UNITS * sx;
 
   return (
     <Svg width={width} height={height}>

--- a/hooks/useCourtPositions.ts
+++ b/hooks/useCourtPositions.ts
@@ -243,6 +243,11 @@ export function useCourtPositions(courtDimensions: CourtDimensions) {
     if (currentIndex < positionHistory.length - 1) setCurrentIndex(prev => prev + 1);
   }, [currentIndex, positionHistory.length]);
 
+  // Jump straight to a history step (3D playback wraps around with this).
+  const goToStep = useCallback((index: number) => {
+    setCurrentIndex(Math.max(0, Math.min(index, positionHistory.length - 1)));
+  }, [positionHistory.length]);
+
   const togglePlayerTrails = useCallback(() => {
     setShowPlayerTrails(prev => !prev);
   }, []);
@@ -314,6 +319,7 @@ export function useCourtPositions(courtDimensions: CourtDimensions) {
     clearSteps,
     undo,
     redo,
+    goToStep,
     canUndo: currentIndex > 0,
     canRedo: currentIndex < positionHistory.length - 1,
     lastStationaryPlayers: positionHistory[currentIndex]?.lastStationaryPositions?.team1 && {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,8 +24,8 @@
         "expo-splash-screen": "~0.30.10",
         "expo-status-bar": "~2.2.3",
         "expo-system-ui": "~5.0.11",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
+        "react": "19.0.0",
+        "react-dom": "19.0.0",
         "react-native": "^0.79.6",
         "react-native-gesture-handler": "~2.24.0",
         "react-native-linear-gradient": "^2.8.3",
@@ -104,6 +104,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1603,6 +1604,17 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -3309,6 +3321,7 @@
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.1.16.tgz",
       "integrity": "sha512-JnnK81JYJ6PiMsuBEshPGHwfagRnH8W7SYdWNrPxQdNtakkHtG4u0O9FmrOnKiPl45DaftCcH1g+OVTFFgWa0Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@react-navigation/core": "^7.12.3",
         "escape-string-regexp": "^4.0.0",
@@ -3564,8 +3577,9 @@
       "version": "19.0.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.14.tgz",
       "integrity": "sha512-ixLZ7zG7j1fM0DijL9hDArwhwcCb4vqmePgwtV0GfnkHRSCUEv4LvzarcTdhoqgyMznUx/EhoTUv31CKZzkQlw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3664,6 +3678,7 @@
       "integrity": "sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.62.1",
         "@typescript-eslint/types": "8.62.1",
@@ -4403,6 +4418,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5181,6 +5197,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -5925,7 +5942,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -6664,6 +6681,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6884,6 +6902,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7148,6 +7167,7 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-53.0.27.tgz",
       "integrity": "sha512-iQwe2uWLb88opUY4vBYEW1d2GUq3lsa43gsMBEdDV+6pw0Oek93l/4nDLe0ODDdrBRjIJm/rdhKqJC/ehHCUqw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "0.24.24",
@@ -7222,6 +7242,7 @@
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-17.1.8.tgz",
       "integrity": "sha512-sOCeMN/BWLA7hBP6lMwoEQzFNgTopk6YY03sBAmwT216IHyL54TjNseg8CRU1IQQ/+qinJ2fYWCl7blx2TiNcA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@expo/config": "~11.0.13",
         "@expo/env": "~1.0.7"
@@ -7246,6 +7267,7 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-13.3.2.tgz",
       "integrity": "sha512-wUlMdpqURmQ/CNKK/+BIHkDA5nGjMqNlYmW0pJFXY/KE/OG80Qcavdu2sHsL4efAIiNGvYdBS10WztuQYU4X0A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -7313,6 +7335,7 @@
       "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-7.1.7.tgz",
       "integrity": "sha512-ZJaH1RIch2G/M3hx2QJdlrKbYFUTOjVVW4g39hfxrE5bPX9xhZUYXqxqQtzMNl1ylAevw9JkgEfWbBWddbZ3UA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "expo-constants": "~17.1.7",
         "invariant": "^2.2.4"
@@ -9022,6 +9045,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -11880,6 +11904,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.1.tgz",
       "integrity": "sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -12262,6 +12287,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
       "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12344,6 +12370,7 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.79.6.tgz",
       "integrity": "sha512-kvIWSmf4QPfY41HC25TR285N7Fv0Pyn3DAEK8qRL9dA35usSaxsJkHfw+VqnonqJjXOaoKCEanwudRAJ60TBGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.79.6",
@@ -12519,6 +12546,7 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.4.0.tgz",
       "integrity": "sha512-JaEThVyJcLhA+vU0NU8bZ0a1ih6GiF4faZ+ArZLqpYbL6j7R3caRqj+mE3lEtKCuHgwjLg3bCxLL1GPUJZVqUA==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -12529,6 +12557,7 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.11.1.tgz",
       "integrity": "sha512-F0zOzRVa3ptZfLpD0J8ROdo+y1fEPw+VBFq1MTY/iyDu08al7qFUO5hLMd+EYMda5VXGaTFCa8q7bOppUszhJw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.1.7",
@@ -12646,6 +12675,7 @@
       "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.20.0.tgz",
       "integrity": "sha512-OOSgrw+aON6R3hRosCau/xVxdLzbjEcsLysYedka0ZON4ZZe6n9xgeN9ZkoejhARM36oTlUgHIQqxGutEJ9Wxg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@react-native/normalize-colors": "^0.74.1",
@@ -14521,6 +14551,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/utils/__tests__/court3d-test.ts
+++ b/utils/__tests__/court3d-test.ts
@@ -1,0 +1,114 @@
+import {
+  arcPath,
+  courtPointFromScreen,
+  makeProjector,
+  MIN_SHOT_DIST,
+  shotBetween,
+  shotPos,
+  THETA_DEFAULT,
+} from '../court3d';
+import { COURT_H, COURT_W } from '../../components/CourtSvg';
+
+const lines = { x: 30, y: 120, width: 342, height: 610 };
+const flat = { b: 0, thetaDeg: THETA_DEFAULT, phiDeg: 0, zoom: 1 };
+const tilted = { b: 1, thetaDeg: THETA_DEFAULT, phiDeg: 0, zoom: 1 };
+
+describe('makeProjector', () => {
+  it('at b=0 matches the 2D CourtSvg mapping exactly for ground points', () => {
+    const project = makeProjector(lines, flat);
+    const sx = lines.width / COURT_W;
+    const sy = lines.height / COURT_H;
+    for (const [x, z] of [
+      [0, 0],
+      [COURT_W, 0],
+      [0, COURT_H],
+      [COURT_W, COURT_H],
+      [305, 670],
+      [46, 472],
+    ]) {
+      const [px, py, s] = project(x, z, 0);
+      expect(px).toBeCloseTo(lines.x + x * sx, 6);
+      expect(py).toBeCloseTo(lines.y + z * sy, 6);
+      expect(s).toBeCloseTo(1, 6);
+    }
+  });
+
+  it('at b=1 the near edge is larger and lower on screen than the far edge', () => {
+    const project = makeProjector(lines, tilted);
+    const far = project(305, 0, 0);
+    const near = project(305, COURT_H, 0);
+    expect(near[2]).toBeGreaterThan(1);
+    expect(far[2]).toBeLessThan(1);
+    expect(near[1]).toBeGreaterThan(far[1]);
+    // Perspective: the near half of the court spans more pixels than the far half
+    const mid = project(305, 670, 0);
+    expect(near[1] - mid[1]).toBeGreaterThan(mid[1] - far[1]);
+  });
+
+  it('keeps the court x-centered when phi=0 and elevates high points', () => {
+    const project = makeProjector(lines, tilted);
+    const centerGround = project(305, 670, 0);
+    const centerHigh = project(305, 670, 300);
+    expect(centerGround[0]).toBeCloseTo(lines.x + lines.width / 2, 6);
+    expect(centerHigh[1]).toBeLessThan(centerGround[1]); // up on screen
+  });
+
+  it('yaw shifts a centered far point sideways', () => {
+    const project = makeProjector(lines, { ...tilted, phiDeg: 15 });
+    const far = project(305, 0, 0);
+    expect(Math.abs(far[0] - (lines.x + lines.width / 2))).toBeGreaterThan(5);
+  });
+
+  it('zoom scales around the court center', () => {
+    const zoomed = makeProjector(lines, { ...flat, zoom: 1.4 });
+    const [px] = zoomed(0, 670, 0);
+    const cx = lines.x + lines.width / 2;
+    expect(px).toBeCloseTo(cx - (lines.width / 2) * 1.4, 6);
+  });
+});
+
+describe('shots', () => {
+  it('ignores moves below the minimum distance', () => {
+    expect(shotBetween({ x: 100, z: 100 }, { x: 100 + MIN_SHOT_DIST - 1, z: 100 })).toBeNull();
+  });
+
+  it('gives a clear-length shot a high slow arc and a kill-length shot a flat one', () => {
+    const clear = shotBetween({ x: 150, z: 1200 }, { x: 460, z: 240 })!; // ~1009cm
+    const kill = shotBetween({ x: 220, z: 780 }, { x: 400, z: 430 })!; // ~394cm
+    expect(clear.peak).toBeGreaterThan(280);
+    expect(clear.peak).toBeLessThanOrEqual(350);
+    expect(kill.peak).toBe(0);
+    expect(clear.dur).toBeGreaterThan(kill.dur);
+    expect(clear.dur).toBeLessThanOrEqual(2000);
+    expect(kill.dur).toBeGreaterThanOrEqual(700);
+  });
+
+  it('flies from launch height to the floor with lift in between', () => {
+    const shot = shotBetween({ x: 100, z: 1100 }, { x: 500, z: 300 })!;
+    const [x0, z0, h0] = shotPos(shot, 0);
+    const [x1, z1, h1] = shotPos(shot, 1);
+    const [, , hMid] = shotPos(shot, 0.5);
+    expect([x0, z0]).toEqual([100, 1100]);
+    expect([x1, z1]).toEqual([500, 300]);
+    expect(h0).toBeGreaterThan(0);
+    expect(h1).toBe(0);
+    expect(hMid).toBeGreaterThan((h0 + h1) / 2);
+  });
+
+  it('builds an SVG path with one point per segment plus the start', () => {
+    const shot = shotBetween({ x: 100, z: 1100 }, { x: 500, z: 300 })!;
+    const d = arcPath(makeProjector(lines, tilted), shot, 0, 1, 8);
+    expect(d.startsWith('M')).toBe(true);
+    expect(d.split('L').length).toBe(9);
+  });
+});
+
+describe('courtPointFromScreen', () => {
+  it('round-trips through the flat projector', () => {
+    const project = makeProjector(lines, flat);
+    const pt = courtPointFromScreen(200, 400, lines);
+    const [px, py] = project(pt.x, pt.z, 0);
+    expect(px).toBeCloseTo(200, 6);
+    expect(py).toBeCloseTo(400, 6);
+  });
+});

--- a/utils/__tests__/court3d-test.ts
+++ b/utils/__tests__/court3d-test.ts
@@ -6,6 +6,8 @@ import {
   shotBetween,
   shotPos,
   THETA_DEFAULT,
+  THETA_MAX,
+  THETA_MIN,
 } from '../court3d';
 import { COURT_H, COURT_W } from '../../components/CourtSvg';
 
@@ -51,6 +53,24 @@ describe('makeProjector', () => {
     const centerHigh = project(305, 670, 300);
     expect(centerGround[0]).toBeCloseTo(lines.x + lines.width / 2, 6);
     expect(centerHigh[1]).toBeLessThan(centerGround[1]); // up on screen
+  });
+
+  it('keeps every corner on screen at any tilt while the court is straight', () => {
+    // The green mat is horizontally centered, so screen width = 2 * center x.
+    const screenW = 2 * (lines.x + lines.width / 2);
+    for (const thetaDeg of [THETA_MIN, THETA_DEFAULT, THETA_MAX]) {
+      const project = makeProjector(lines, { b: 1, thetaDeg, phiDeg: 0, zoom: 1 });
+      for (const [x, z] of [
+        [0, 0],
+        [COURT_W, 0],
+        [0, COURT_H],
+        [COURT_W, COURT_H],
+      ]) {
+        const [px] = project(x, z, 0);
+        expect(px).toBeGreaterThanOrEqual(0);
+        expect(px).toBeLessThanOrEqual(screenW);
+      }
+    }
   });
 
   it('yaw shifts a centered far point sideways', () => {

--- a/utils/court3d.ts
+++ b/utils/court3d.ts
@@ -1,0 +1,172 @@
+import {
+  CENTER_X,
+  COURT_H,
+  COURT_W,
+  LinesRect,
+  LONG_SERVICE_Y,
+  NET_OVERHANG_UNITS,
+  NET_Y,
+  SHORT_SERVICE_Y,
+  SINGLES_X,
+} from '../components/CourtSvg';
+
+/**
+ * Perspective projection for the tilt-to-3D court view.
+ *
+ * Court space: 1 unit = 1 cm, x 0..610 (left→right), z 0..1340 (top→bottom
+ * of the 2D court), h up. At b=0 (flat) a ground point projects to exactly
+ * the same screen point CourtSvg paints it at, so the 2D↔3D tilt morphs
+ * seamlessly from the existing court.
+ */
+
+export interface CamState {
+  /** Tilt blend: 0 = flat 2D court, 1 = fully tilted 3D. */
+  b: number;
+  thetaDeg: number;
+  phiDeg: number;
+  zoom: number;
+}
+
+export const THETA_DEFAULT = 48;
+export const THETA_MIN = 24;
+export const THETA_MAX = 60;
+export const PHI_MAX = 18;
+export const ZOOM_MIN = 0.8;
+export const ZOOM_MAX = 1.4;
+
+export const NET_POST_H = 155; // BWF net height at the posts, cm
+
+// Tuned in the design prototype: camera distance and height exaggeration are
+// in court cm; the scale boost/center lift keep the tilted court filling the
+// space the foreshortening frees up.
+const CAM_DIST = 1900;
+const HEIGHT_LIFT = 0.55;
+const TILT_SCALE_BOOST = 1.214;
+const TILT_CENTER_LIFT = 0.075;
+
+export type Projected = readonly [x: number, y: number, scale: number];
+export type Projector = (x: number, z: number, h?: number) => Projected;
+
+export function makeProjector(lines: LinesRect, cam: CamState): Projector {
+  const th = (cam.thetaDeg * Math.PI) / 180 * cam.b;
+  const ph = (cam.phiDeg * Math.PI) / 180 * cam.b;
+  const ct = Math.cos(th);
+  const st = Math.sin(th);
+  const cp = Math.cos(ph);
+  const sp = Math.sin(ph);
+  const sx2d = lines.width / COURT_W;
+  const sy2d = lines.height / COURT_H;
+  const s3d = TILT_SCALE_BOOST * sx2d;
+  const scaleX = (sx2d + (s3d - sx2d) * cam.b) * cam.zoom;
+  const scaleY = (sy2d + (s3d - sy2d) * cam.b) * cam.zoom;
+  const cx = lines.x + lines.width / 2;
+  const cy = lines.y + lines.height / 2 - TILT_CENTER_LIFT * lines.height * cam.b;
+
+  return (x, z, h = 0) => {
+    const xc = x - COURT_W / 2;
+    const zc = z - COURT_H / 2;
+    const xr = xc * cp - zc * sp; // yaw around the court center
+    const zr = xc * sp + zc * cp;
+    const hh = h * HEIGHT_LIFT;
+    const yr = zr * ct - hh * st; // tilt toward the camera
+    const depth = zr * st + hh * ct;
+    const s = CAM_DIST / (CAM_DIST - depth);
+    return [cx + xr * s * scaleX, cy + yr * s * scaleY, s];
+  };
+}
+
+export interface CourtPoint {
+  x: number;
+  z: number;
+}
+
+export interface Shot {
+  p0: CourtPoint;
+  p1: CourtPoint;
+  h0: number; // launch height (racket contact)
+  peak: number; // extra parabolic lift at mid-flight
+  dur: number; // flight time, ms
+}
+
+const HIT_HEIGHT = 170;
+export const MIN_SHOT_DIST = 12; // below this the shuttle "didn't move"
+export const REST_STEP_MS = 900; // dwell on a step whose shuttle stayed put
+
+// ponytail: arc height & flight time inferred from shot length (long = high
+// clear, short = flat kill), fit to the design prototype's rally; use a real
+// per-shot type if steps ever carry one.
+export function shotBetween(from: CourtPoint, to: CourtPoint): Shot | null {
+  const dist = Math.hypot(to.x - from.x, to.z - from.z);
+  if (dist < MIN_SHOT_DIST) return null;
+  return {
+    p0: from,
+    p1: to,
+    h0: HIT_HEIGHT,
+    peak: Math.min(350, Math.max(0, 0.67 * dist - 348)),
+    dur: Math.min(2000, Math.max(700, 600 + dist * 1.28)),
+  };
+}
+
+/** Shuttle position along a shot at t ∈ [0,1] → [x, z, h]. */
+export function shotPos(shot: Shot, t: number): [number, number, number] {
+  const { p0, p1 } = shot;
+  return [
+    p0.x + (p1.x - p0.x) * t,
+    p0.z + (p1.z - p0.z) * t,
+    shot.h0 * (1 - t) + 4 * shot.peak * t * (1 - t),
+  ];
+}
+
+export function arcPath(
+  project: Projector,
+  shot: Shot,
+  t0: number,
+  t1: number,
+  segments = 20
+): string {
+  let d = '';
+  for (let i = 0; i <= segments; i++) {
+    const [x, z, h] = shotPos(shot, t0 + ((t1 - t0) * i) / segments);
+    const p = project(x, z, h);
+    d += (i ? 'L' : 'M') + p[0].toFixed(1) + ' ' + p[1].toFixed(1) + ' ';
+  }
+  return d;
+}
+
+/** Marker-center screen point → court units. */
+export function courtPointFromScreen(cx: number, cy: number, lines: LinesRect): CourtPoint {
+  return {
+    x: ((cx - lines.x) / lines.width) * COURT_W,
+    z: ((cy - lines.y) / lines.height) * COURT_H,
+  };
+}
+
+// Painted line segments [x1, z1, x2, z2] — same geometry CourtSvg draws flat.
+const S0 = SHORT_SERVICE_Y[0];
+const S1 = SHORT_SERVICE_Y[1];
+export const COURT_LINE_SEGMENTS: readonly (readonly [number, number, number, number])[] = [
+  [0, 0, COURT_W, 0],
+  [0, COURT_H, COURT_W, COURT_H],
+  [0, 0, 0, COURT_H],
+  [COURT_W, 0, COURT_W, COURT_H],
+  [SINGLES_X[0], 0, SINGLES_X[0], COURT_H],
+  [SINGLES_X[1], 0, SINGLES_X[1], COURT_H],
+  [0, LONG_SERVICE_Y[0], COURT_W, LONG_SERVICE_Y[0]],
+  [0, LONG_SERVICE_Y[1], COURT_W, LONG_SERVICE_Y[1]],
+  [0, S0, COURT_W, S0],
+  [0, S1, COURT_W, S1],
+  [CENTER_X, 0, CENTER_X, S0],
+  [CENTER_X, S1, CENTER_X, COURT_H],
+];
+
+export function courtLinesPath(project: Projector): string {
+  return COURT_LINE_SEGMENTS.map((l) => {
+    const a = project(l[0], l[1]);
+    const b = project(l[2], l[3]);
+    return `M${a[0].toFixed(1)} ${a[1].toFixed(1)} L${b[0].toFixed(1)} ${b[1].toFixed(1)}`;
+  }).join(' ');
+}
+
+export const NET_X0 = -NET_OVERHANG_UNITS;
+export const NET_X1 = COURT_W + NET_OVERHANG_UNITS;
+export { COURT_W, COURT_H, NET_Y };

--- a/utils/court3d.ts
+++ b/utils/court3d.ts
@@ -35,12 +35,14 @@ export const PHI_MAX = 18;
 export const NET_POST_H = 155; // BWF net height at the posts, cm
 
 // Tuned in the design prototype: camera distance and height exaggeration are
-// in court cm; the scale boost/center lift keep the tilted court filling the
-// space the foreshortening frees up.
+// in court cm; the center lift keeps the tilted court visually centered.
 const CAM_DIST = 1900;
 const HEIGHT_LIFT = 0.55;
-const TILT_SCALE_BOOST = 1.214;
 const TILT_CENTER_LIFT = 0.075;
+// Full-tilt zoom is fit-driven: the near corners — the widest projected
+// points, at the steepest allowed tilt — stay this far inside the screen
+// edge while the court is straight. Yaw may push them off-screen.
+const FIT_MARGIN = 8;
 
 export type Projected = readonly [x: number, y: number, scale: number];
 export type Projector = (x: number, z: number, h?: number) => Projected;
@@ -54,11 +56,13 @@ export function makeProjector(lines: LinesRect, cam: CamState): Projector {
   const sp = Math.sin(ph);
   const sx2d = lines.width / COURT_W;
   const sy2d = lines.height / COURT_H;
-  const s3d = TILT_SCALE_BOOST * sx2d;
+  const cx = lines.x + lines.width / 2; // the mat is centered, so cx = half the screen
+  const cy = lines.y + lines.height / 2 - TILT_CENTER_LIFT * lines.height * cam.b;
+  const sNearMax =
+    CAM_DIST / (CAM_DIST - (COURT_H / 2) * Math.sin((THETA_MAX * Math.PI) / 180));
+  const s3d = (cx - FIT_MARGIN) / ((COURT_W / 2) * sNearMax);
   const scaleX = (sx2d + (s3d - sx2d) * cam.b) * cam.zoom;
   const scaleY = (sy2d + (s3d - sy2d) * cam.b) * cam.zoom;
-  const cx = lines.x + lines.width / 2;
-  const cy = lines.y + lines.height / 2 - TILT_CENTER_LIFT * lines.height * cam.b;
 
   return (x, z, h = 0) => {
     const xc = x - COURT_W / 2;

--- a/utils/court3d.ts
+++ b/utils/court3d.ts
@@ -31,8 +31,6 @@ export const THETA_DEFAULT = 48;
 export const THETA_MIN = 24;
 export const THETA_MAX = 60;
 export const PHI_MAX = 18;
-export const ZOOM_MIN = 0.8;
-export const ZOOM_MAX = 1.4;
 
 export const NET_POST_H = 155; // BWF net height at the posts, cm
 


### PR DESCRIPTION
## What

A 2D/3D segmented toggle in the header tilts the court into a perspective "world" view, ported from the Height 3D design prototype. The tilt is a 430 ms tween whose projection at b=0 matches the flat court mapping exactly, so the court morphs rather than cuts.

In 3D:

- drag to rotate and tilt (tilt 24–60°, yaw ±18°); the court turns with the finger, holds briefly in a soft detent at straight-on, and the whole court fits on screen while straight (fit-driven zoom at the steepest tilt)
- steps play back as shuttle flights: height-lifted arcs with a landing ring, drop line and ground shadow; only the current flight is drawn, matching 2D's last-move-only trails. Arc height and flight time are inferred from shot length (long = high clear, short = flat kill)
- player pins (discs on stems with floor shadows, using each marker's color/size) glide between steps
- the dock swaps to Back / Play / Next; they drive the same step history as 2D undo/redo and wrap into a looping rally

Trails/Shuttle keep their 2D meanings in 3D: player floor trails and shuttle arc visuals.

## Integration with #17

- Only one playback clock runs at a time: entering 3D pauses the 2D step interval and vice versa.
- In 3D the playback dock is replaced by the 3D transport (Fork stays a 2D action).
- The loaded-drill name pill and its progress bar stay visible in 3D and update live during 3D playback.
- The lock and Together banners are 2D-only (nothing is draggable in 3D).

## Implementation

- `utils/court3d.ts` — projection (theta/phi/zoom/blend), shot arcs, screen↔court conversion; court geometry shared from `CourtSvg`. Unit-tested, including the b=0 ↔ 2D equivalence invariant that makes the morph seamless.
- `components/Court3DView.tsx` — the SVG scene, gesture surface, and rAF flight loop.
- `hooks/useCourtPositions.ts` — adds `goToStep(index)` for wrap-around navigation.

## Testing

- `npx jest` 71 passing (10 new), `tsc --noEmit` and `expo lint` clean.
- Release APK driven on an Android 15 AVD: 2D↔3D morph, orbit drag (court follows the finger), recording steps, looping 3D playback (flights, landing rings, ghosts), pause/back/next, both toggles, drill-playback × 3D interplay, and a 2D drag regression pass.
- Two new CUF video flows: `05-together-step` (arm Together, two drags commit as one step, Undo rewinds both) and `06-tilt-3d-drill` (load a vault drill, tilt to 3D, pan-rotate mid-playback, round-trip to 2D). All six Maestro flows pass locally against the release APK.

## Known limits

- Orbit angle resets to the default 48° on each 3D entry.
- 3D pins use a generic person glyph (custom icons/photos stay 2D-only for now).
- The step-speed slider paces 2D playback; 3D flight times come from shot length.

## Open question for review

In one emulator run the step pointer appeared to read one step lower after switching 3D→2D mid-playback (4/9 → 3/9). Three scripted repro attempts — pause-then-switch, switch-while-playing, and the original timing across the loop wrap — all preserved the pointer exactly, and no code path decrements it (3D Back/Next/advance only `redo`/`goToStep`). Likely an adb screencap timing artifact, but flagging it so reviewers keep an eye on the pointer when toggling modes mid-play.
