### PR TITLE
feat(reviews): Play in-app review prompt after second drill save

### DIFF
--- a/components/BadmintonCourt.tsx
+++ b/components/BadmintonCourt.tsx
@@ -18,6 +18,7 @@ import { drillStepsForCourt, VaultDrill } from '../data/vaultDrills';
 import { useVaultAccess } from '../hooks/useVaultAccess';
 import { useMarkerCustomization } from '../context/MarkerCustomizationContext';
 import { createStepSet, decodeSharedStepSet } from '../utils/stepSharing';
+import { maybeAskQuarterlyReview } from '../utils/reviewPrompt';
 import { NormalizedStep, StepSet } from '../types/drill';
 import { palette, radii, shadows, sora, spacing } from '../constants/theme';
 
@@ -421,6 +422,10 @@ export default function BadmintonCourt() {
     });
 
     return () => subscription.remove();
+  }, []);
+
+  useEffect(() => {
+    maybeAskQuarterlyReview();
   }, []);
 
   const handleSaveStepSet = useCallback(async (name: string) => {

--- a/hooks/useStepSets.ts
+++ b/hooks/useStepSets.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { StepSet } from '../types/drill';
 import { appAlert } from '../utils/appAlert';
+import { recordSaveForReviewPrompt } from '../utils/reviewPrompt';
 
 const STORAGE_KEY = 'badminton-step-sets';
 /** Free tier keeps this many saved drills; Drill Vault Pro lifts the cap. */
@@ -72,6 +73,9 @@ export function useStepSets({ isPro = false, onLimitReached }: UseStepSetsOption
       writeToStorage(next);
       return next;
     });
+    // Fire-and-forget: a successful save is the engagement signal for the
+    // one-time Play in-app review prompt.
+    recordSaveForReviewPrompt();
     return stepSet;
   }, [stepSets, isPro, onLimitReached]);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "expo-screen-orientation": "~8.1.7",
         "expo-splash-screen": "~0.30.10",
         "expo-status-bar": "~2.2.3",
+        "expo-store-review": "~8.1.5",
         "expo-system-ui": "~5.0.11",
         "react": "19.0.0",
         "react-dom": "19.0.0",
@@ -7463,6 +7464,16 @@
       },
       "peerDependencies": {
         "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-store-review": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/expo-store-review/-/expo-store-review-8.1.5.tgz",
+      "integrity": "sha512-PMNMIt6UrdMYyRzCCbmCmbIkwSgIXhGNQHsgmOgq9FgtYLW5Oo2FD3zwB0KU2u/MpTTt/XyuuADuFvxE+Vh9uw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
         "react-native": "*"
       }
     },

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "expo-screen-orientation": "~8.1.7",
     "expo-splash-screen": "~0.30.10",
     "expo-status-bar": "~2.2.3",
+    "expo-store-review": "~8.1.5",
     "expo-system-ui": "~5.0.11",
     "react": "19.0.0",
     "react-dom": "19.0.0",

--- a/utils/__tests__/reviewPrompt-test.ts
+++ b/utils/__tests__/reviewPrompt-test.ts
@@ -1,6 +1,8 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Linking } from 'react-native';
 import * as StoreReview from 'expo-store-review';
-import { recordSaveForReviewPrompt } from '../reviewPrompt';
+import { appAlert, AppAlertButton } from '../appAlert';
+import { maybeAskQuarterlyReview, QUARTER_MS, recordSaveForReviewPrompt } from '../reviewPrompt';
 
 jest.mock('@react-native-async-storage/async-storage', () =>
   // eslint-disable-next-line @typescript-eslint/no-require-imports -- jest.mock factories cannot use import
@@ -10,8 +12,11 @@ jest.mock('expo-store-review', () => ({
   hasAction: jest.fn(async () => true),
   requestReview: jest.fn(async () => {}),
 }));
+jest.mock('../appAlert', () => ({ appAlert: jest.fn() }));
 
 const mockedReview = StoreReview as jest.Mocked<typeof StoreReview>;
+const mockedAlert = appAlert as jest.MockedFunction<typeof appAlert>;
+const mockedOpenURL = jest.spyOn(Linking, 'openURL').mockResolvedValue(true);
 
 describe('recordSaveForReviewPrompt', () => {
   beforeEach(async () => {
@@ -49,5 +54,58 @@ describe('recordSaveForReviewPrompt', () => {
   it('never throws even when storage fails', async () => {
     jest.spyOn(AsyncStorage, 'getItem').mockRejectedValueOnce(new Error('disk'));
     await expect(recordSaveForReviewPrompt()).resolves.toBeUndefined();
+  });
+});
+
+describe('maybeAskQuarterlyReview', () => {
+  const T0 = 1_700_000_000_000;
+
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  const rateButton = (): AppAlertButton => {
+    const buttons = mockedAlert.mock.calls.at(-1)?.[2] ?? [];
+    const rate = buttons.find((b) => b.text.includes('rate'));
+    expect(rate).toBeDefined();
+    return rate!;
+  };
+
+  it('arms the timer on first launch without asking', async () => {
+    await maybeAskQuarterlyReview(T0);
+    expect(mockedAlert).not.toHaveBeenCalled();
+  });
+
+  it('asks only once a quarter has passed', async () => {
+    await maybeAskQuarterlyReview(T0);
+    await maybeAskQuarterlyReview(T0 + QUARTER_MS - 1000);
+    expect(mockedAlert).not.toHaveBeenCalled();
+
+    await maybeAskQuarterlyReview(T0 + QUARTER_MS + 1000);
+    expect(mockedAlert).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-asks each quarter until the user rates', async () => {
+    await maybeAskQuarterlyReview(T0);
+    await maybeAskQuarterlyReview(T0 + QUARTER_MS + 1000);
+    expect(mockedAlert).toHaveBeenCalledTimes(1);
+
+    // Dismissed without rating: quiet until the next quarter, then asks again.
+    await maybeAskQuarterlyReview(T0 + QUARTER_MS + 2000);
+    expect(mockedAlert).toHaveBeenCalledTimes(1);
+    await maybeAskQuarterlyReview(T0 + 2 * QUARTER_MS + 2000);
+    expect(mockedAlert).toHaveBeenCalledTimes(2);
+  });
+
+  it('opens the Play listing and never asks again after rating', async () => {
+    await maybeAskQuarterlyReview(T0);
+    await maybeAskQuarterlyReview(T0 + QUARTER_MS + 1000);
+    rateButton().onPress?.();
+    await Promise.resolve();
+    expect(mockedOpenURL).toHaveBeenCalledWith(expect.stringContaining('market://details'));
+
+    await maybeAskQuarterlyReview(T0 + 5 * QUARTER_MS);
+    expect(mockedAlert).toHaveBeenCalledTimes(1);
   });
 });

--- a/utils/__tests__/reviewPrompt-test.ts
+++ b/utils/__tests__/reviewPrompt-test.ts
@@ -1,0 +1,53 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as StoreReview from 'expo-store-review';
+import { recordSaveForReviewPrompt } from '../reviewPrompt';
+
+jest.mock('@react-native-async-storage/async-storage', () =>
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- jest.mock factories cannot use import
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+);
+jest.mock('expo-store-review', () => ({
+  hasAction: jest.fn(async () => true),
+  requestReview: jest.fn(async () => {}),
+}));
+
+const mockedReview = StoreReview as jest.Mocked<typeof StoreReview>;
+
+describe('recordSaveForReviewPrompt', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+    jest.clearAllMocks();
+    mockedReview.hasAction.mockResolvedValue(true);
+  });
+
+  it('does not prompt on the first save', async () => {
+    await recordSaveForReviewPrompt();
+    expect(mockedReview.requestReview).not.toHaveBeenCalled();
+  });
+
+  it('prompts exactly once at the engagement threshold', async () => {
+    await recordSaveForReviewPrompt();
+    await recordSaveForReviewPrompt();
+    expect(mockedReview.requestReview).toHaveBeenCalledTimes(1);
+
+    await recordSaveForReviewPrompt();
+    await recordSaveForReviewPrompt();
+    expect(mockedReview.requestReview).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries later when the review action is unavailable', async () => {
+    mockedReview.hasAction.mockResolvedValue(false);
+    await recordSaveForReviewPrompt();
+    await recordSaveForReviewPrompt();
+    expect(mockedReview.requestReview).not.toHaveBeenCalled();
+
+    mockedReview.hasAction.mockResolvedValue(true);
+    await recordSaveForReviewPrompt();
+    expect(mockedReview.requestReview).toHaveBeenCalledTimes(1);
+  });
+
+  it('never throws even when storage fails', async () => {
+    jest.spyOn(AsyncStorage, 'getItem').mockRejectedValueOnce(new Error('disk'));
+    await expect(recordSaveForReviewPrompt()).resolves.toBeUndefined();
+  });
+});

--- a/utils/reviewPrompt.ts
+++ b/utils/reviewPrompt.ts
@@ -1,10 +1,19 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Linking } from 'react-native';
 import * as StoreReview from 'expo-store-review';
+import { appAlert } from './appAlert';
 
 const SAVE_COUNT_KEY = 'review-save-count';
 const PROMPTED_KEY = 'review-prompted';
 /** Ask only after this many saved drills — proven engagement, not a nag. */
 const SAVES_BEFORE_PROMPT = 2;
+
+const NEXT_ASK_KEY = 'review-next-ask-at';
+const RATED_KEY = 'review-rated';
+export const QUARTER_MS = 90 * 24 * 60 * 60 * 1000;
+const MARKET_URL = 'market://details?id=com.haritabhgupta.badmintoncourtsimulator';
+const PLAY_URL =
+  'https://play.google.com/store/apps/details?id=com.haritabhgupta.badmintoncourtsimulator';
 
 /**
  * Counts a successful drill save and, once the user has shown real
@@ -28,5 +37,43 @@ export async function recordSaveForReviewPrompt(): Promise<void> {
     await StoreReview.requestReview();
   } catch {
     // Never let review plumbing break a save.
+  }
+}
+
+/**
+ * Every 90 days, one light-hearted nudge toward the Play Store listing —
+ * stops forever once the user taps through to rate. Uses our own dialog and
+ * a store deep link (not the in-app review API, whose rules forbid asking
+ * questions around its card, and which never reveals whether/what anyone
+ * rated). Call once per app launch.
+ */
+export async function maybeAskQuarterlyReview(now: number = Date.now()): Promise<void> {
+  try {
+    if (await AsyncStorage.getItem(RATED_KEY)) return;
+
+    const nextAskAt = await AsyncStorage.getItem(NEXT_ASK_KEY);
+    if (!nextAskAt) {
+      await AsyncStorage.setItem(NEXT_ASK_KEY, String(now + QUARTER_MS));
+      return;
+    }
+    if (now < Number(nextAskAt)) return;
+
+    // Re-arm before showing so an interrupted dialog waits a full quarter.
+    await AsyncStorage.setItem(NEXT_ASK_KEY, String(now + QUARTER_MS));
+
+    appAlert('A quick rally 🏸', 'Do you like Featherwork? Be honest — the shuttle can take it.', [
+      { text: 'Not now', style: 'cancel' },
+      {
+        text: 'Love it — rate it ⭐',
+        onPress: () => {
+          AsyncStorage.setItem(RATED_KEY, '1').catch(() => {});
+          Linking.openURL(MARKET_URL).catch(() =>
+            Linking.openURL(PLAY_URL).catch(() => {})
+          );
+        },
+      },
+    ]);
+  } catch {
+    // Never let review plumbing break app launch.
   }
 }

--- a/utils/reviewPrompt.ts
+++ b/utils/reviewPrompt.ts
@@ -1,0 +1,32 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as StoreReview from 'expo-store-review';
+
+const SAVE_COUNT_KEY = 'review-save-count';
+const PROMPTED_KEY = 'review-prompted';
+/** Ask only after this many saved drills — proven engagement, not a nag. */
+const SAVES_BEFORE_PROMPT = 2;
+
+/**
+ * Counts a successful drill save and, once the user has shown real
+ * engagement, requests Play's native in-app review dialog — once ever.
+ * Play additionally rate-limits and may skip the dialog; every failure is
+ * swallowed so review plumbing can never affect the save flow.
+ */
+export async function recordSaveForReviewPrompt(): Promise<void> {
+  try {
+    if (await AsyncStorage.getItem(PROMPTED_KEY)) return;
+
+    const count = Number((await AsyncStorage.getItem(SAVE_COUNT_KEY)) ?? '0') + 1;
+    await AsyncStorage.setItem(SAVE_COUNT_KEY, String(count));
+    if (count < SAVES_BEFORE_PROMPT) return;
+
+    // No Play services (e.g. bare emulator): skip now, retry on a later save.
+    if (!(await StoreReview.hasAction())) return;
+
+    // Mark before requesting so an interrupted dialog can never re-prompt.
+    await AsyncStorage.setItem(PROMPTED_KEY, '1');
+    await StoreReview.requestReview();
+  } catch {
+    // Never let review plumbing break a save.
+  }
+}


### PR DESCRIPTION
## Summary

Two-layer review strategy, both engagement-gated and non-nagging:

**1. Launch prompt (Play in-app review API)** — requested once ever, after the user's second successful drill save (manual saves, vault bookmarks and link imports all count via `saveStepSet`). `hasAction()` gate skips quietly off-Play and retries on a later save; prompted flag written before requesting so an interrupted dialog can't re-prompt; all failures swallowed.

**2. Quarterly nudge (own dialog → Play listing)** — every 90 days on launch: *“A quick rally 🏸 — Do you like Featherwork? Be honest — the shuttle can take it.”* “Love it — rate it ⭐” opens the store listing (market:// with web fallback) and permanently stops future asks; “Not now” re-arms for the next quarter. Timer re-armed before showing, so an interrupted dialog also waits a full quarter.

**Why the second layer doesn't reuse the in-app review API:** the API never reveals whether/what a user rated, and its policy forbids asking questions before or around its card — so the re-ask uses our own dialog with a store deep link, which has no such constraint.

## Test plan
- 8 jest tests (80 total passing): first-save silence, threshold once-ever, Play-unavailable retry, storage-failure safety; quarterly arming, quarter boundary, per-quarter repeat until rated, rate-tap → market:// + permanent stop
- AVD smoke: saves fire the prompt path without crash (in-app dialog itself is Play-gated); day-0 launch arms the quarterly timer silently
- tsc / eslint clean