### PR TITLE
fix(paywall): drop shipped auto-play from the coming-soon list

### DIFF
--- a/components/ProPaywall.tsx
+++ b/components/ProPaywall.tsx
@@ -109,7 +109,6 @@ export function ProPaywall({ visible, onClose, vault, onSubscribed }: ProPaywall
 
             <Text style={styles.comingSoonLabel}>Coming soon to Pro</Text>
             {[
-              { icon: 'play-speed', text: 'Auto-play practice mode for courtside training' },
               { icon: 'account-group-outline', text: 'Club workspace: team libraries & session plans' },
             ].map(({ icon, text }) => (
               <View key={text} style={styles.bulletRow}>


### PR DESCRIPTION
Drill playback (Play button, speed control) shipped app-wide in #17/#19 — keeping "Auto-play practice mode" under **Coming soon to Pro** is now a stale promise on the paywall, and it describes something that's actually free for everyone. Removed; the Club workspace teaser stays.

Pre-production copy-honesty fix; no logic changes. tsc / eslint / 80 jest tests clean.