### PR TITLE
fix(links): drop debug keystore fingerprint from assetlinks source copy

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -115,8 +115,10 @@ android {
                 keyAlias keystoreProperties['keyAlias']
                 keyPassword keystoreProperties['keyPassword']
             } else {
-                // Local/test release builds: sign with debug keystore so the
-                // debug SHA256 in assetlinks.json keeps App Links verified.
+                // Local/test release builds: sign with debug keystore. Note:
+                // assetlinks.json serves only the Play signing cert, so these
+                // builds won't auto-verify App Links (use `adb shell pm
+                // set-app-links ... 2 all` to force-verify when testing).
                 storeFile file('debug.keystore')
                 storePassword 'android'
                 keyAlias 'androiddebugkey'

--- a/links-site/.well-known/assetlinks.json
+++ b/links-site/.well-known/assetlinks.json
@@ -5,7 +5,8 @@
       "namespace": "android_app",
       "package_name": "com.haritabhgupta.badmintoncourtsimulator",
       "sha256_cert_fingerprints": [
-        "74:44:7C:28:51:BA:D4:94:0A:F6:CC:1E:93:07:4B:87:31:E3:48:FB:BB:B5:2B:CD:9E:66:95:73:95:7E:DE:B6"
+        "C4:89:50:D4:DC:2A:3D:CE:B4:68:ED:7D:6C:96:06:5C:C0:6B:7B:C6:BE:AA:92:67:66:3E:99:69:04:1B:A4:7E",
+        "5B:49:40:86:66:A8:A3:1C:2B:B7:33:51:3A:50:20:4E:EE:0C:48:BC:03:07:FA:B1:99:82:DF:46:0A:8B:B0:CC"
       ]
     }
   }

--- a/links-site/README.md
+++ b/links-site/README.md
@@ -16,17 +16,18 @@ Deploy **contents of this folder** (not the `links-site` folder itself) to the r
 
 ## Release fingerprint
 
-`assetlinks.json` includes the **debug** keystore SHA256 for local/emulator builds.
+`assetlinks.json` includes only the **Play App Signing** certificate SHA256
+(Play Console → **Setup → App signing → App signing key certificate**).
+The debug keystore fingerprint is deliberately excluded — the debug keystore is
+committed to a public repo, so listing it would let anyone's rebuild pass App
+Links verification for this domain.
 
-For Play Store builds, add your **release/upload** certificate SHA256:
+Local/emulator builds therefore don't auto-verify links. To test link import
+locally, either tap through the app-chooser dialog or force verification:
 
 ```bash
-keytool -list -v -keystore YOUR_RELEASE_KEYSTORE -alias YOUR_ALIAS
+adb shell pm set-app-links --package com.haritabhgupta.badmintoncourtsimulator 2 all
 ```
-
-Or Play Console → **Setup → App signing → SHA-256 certificate fingerprint**.
-
-Append the fingerprint to the `sha256_cert_fingerprints` array in `.well-known/assetlinks.json`.
 
 ## Share URL format
 


### PR DESCRIPTION
Companion to badmlabs/badmlabs.github.io#2 (already merged and live).

The debug keystore is committed to this public repo, so serving its fingerprint in `assetlinks.json` let anyone's rebuild pass App Links verification for badmlabs.github.io. The live site now serves only the Play App Signing and upload certs.

This PR syncs the `links-site/` source copy with what's deployed and updates the stale docs:
- `links-site/.well-known/assetlinks.json` — debug fingerprint removed, Play signing + upload certs kept
- `links-site/README.md` — documents why the debug cert is excluded and how to force-verify App Links locally (`adb shell pm set-app-links ... 2 all`)
- `android/app/build.gradle` — comment on the debug-keystore release fallback no longer claims assetlinks verifies it