### PR TITLE
chore(prod-prep): in-app privacy policy link and release runbook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,20 @@ Ground truth for saved drills: use a `google_apis` (non-Play) emulator image so 
 - `context/` — app state (React context)
 - `utils/`, `types/`, `constants/`, `hooks/` — what they say
 
+## Releases
+
+- Versions live in **app.json only** (`expo.version` + `expo.android.versionCode`); CI's `expo prebuild` stamps them over build.gradle, so bumping build.gradle alone gets silently reverted.
+- Flow: merge PRs to main → bump app.json on main (`chore(release): bump to X.Y.Z (versionCode N)`) → create tag `vX.Y.Z` targeting main (GitHub release) → the tag run builds **and deploys to the Play internal track** via fastlane. Push-to-main runs build only.
+- Every uploaded artifact needs a fresh, higher `versionCode` — a failed upload does *not* consume its code.
+- Play rejects artifacts that declare the BILLING permission without a packaged Billing Library ≥ 6.0.1 (react-native-purchases satisfies this).
+
+### Production-day checklist (deliberately deferred until first prod rollout)
+
+- Play listing **App name → `Featherwork: Badminton Drills`**, plus descriptions and `store-assets/` screenshots/feature graphic/promo video (kept out of the listing until production on purpose).
+- App content forms: Data safety (collects Purchase history + device IDs, nothing shared), content rating questionnaire, ads = none, target audience 13+.
+- Privacy policy URL: `https://badmlabs.github.io/privacy.html`.
+- Glance at the Pre-launch report, then promote the current internal release to Production (staged rollout: start at 20%, go 100% after ~48 quiet hours).
+
 ## Conventions
 
 - Commit messages: Conventional Commits, `type(scope): description`.

--- a/components/SettingsPanel.tsx
+++ b/components/SettingsPanel.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import {
   Image,
+  Linking,
   Modal,
   ScrollView,
   StyleSheet,
@@ -807,6 +808,23 @@ export function SettingsPanel({
           </View>
         </TouchableOpacity>
       )}
+
+      <Text style={styles.sectionLabel}>About</Text>
+      <TouchableOpacity
+        style={styles.aboutRow}
+        onPress={() =>
+          Linking.openURL('https://badmlabs.github.io/privacy.html').catch(() => {})
+        }
+        accessibilityLabel="Privacy policy"
+      >
+        <MaterialCommunityIcons
+          name="shield-lock-outline"
+          size={17}
+          color={palette.textSecondary}
+        />
+        <Text style={styles.aboutRowText}>Privacy Policy</Text>
+        <MaterialCommunityIcons name="open-in-new" size={14} color={palette.textMuted} />
+      </TouchableOpacity>
     </>
   );
 
@@ -1407,6 +1425,23 @@ const styles = StyleSheet.create({
     color: palette.textMuted,
     marginTop: spacing.xs,
     marginBottom: 7,
+  },
+  aboutRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    backgroundColor: palette.card,
+    borderWidth: 1,
+    borderColor: palette.cardBorder,
+    borderRadius: radii.md,
+    paddingVertical: 11,
+    paddingHorizontal: spacing.md,
+  },
+  aboutRowText: {
+    ...sora('600'),
+    flex: 1,
+    color: palette.textPrimary,
+    fontSize: 13,
   },
   modeCard: {
     flexDirection: 'row',


### PR DESCRIPTION
## Summary

Final pre-production items:

1. **In-app Privacy Policy link** — an *About* row at the end of Customize → Court tab opening `https://badmlabs.github.io/privacy.html`. The listing URL alone satisfies Play policy, but an in-app path is expected practice and reviewers look for it.
2. **AGENTS.md → Releases section** — institutionalizes what we learned the hard way: versions bump in app.json only (prebuild overwrites build.gradle), the merge → bump → tag → internal-track flow, versionCode consumption rules, the billing-library requirement, and the **production-day checklist** (listing rename to `Featherwork: Badminton Drills`, store-asset uploads, content forms, staged rollout) — deliberately deferred items now live in the repo instead of chat history.

## Test plan
- tsc / eslint / jest all green; UI change is one link row using existing card tokens