### PR TITLE
feat(updates): wire EAS Update for OTA content drops

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,13 @@ Ground truth for saved drills: use a `google_apis` (non-Play) emulator image so 
 - Every uploaded artifact needs a fresh, higher `versionCode` — a failed upload does *not* consume its code.
 - Play rejects artifacts that declare the BILLING permission without a packaged Billing Library ≥ 6.0.1 (react-native-purchases satisfies this).
 
+### OTA updates (EAS Update)
+
+- All content is JS (drills in `data/vaultDrills.ts`, mascots/themes in components), so monthly drops ship over the air without a store release: `npx eas-cli update --branch production --message "..."` (needs `npx eas-cli login`; project `@haritabh1992/badminton-court-simulator`).
+- `expo.runtimeVersion` in app.json is a manually pinned string (bare workflow — version policies are unsupported by `eas update`). **Bump it in any release that changes native code** (Expo SDK upgrade, new native module/dep); leave it alone for JS-only releases so one publish reaches every store build sharing that runtime.
+- Clients download the update in the background on launch and apply it on the **next** launch (`EXPO_UPDATES_CHECK_ON_LAUNCH=ALWAYS`, `LAUNCH_WAIT_MS=0`).
+- The update channel is baked into builds via `updates.requestHeaders` in app.json (channel `production` → EAS branch `production`).
+
 ### Production-day checklist (deliberately deferred until first prod rollout)
 
 - Play listing **App name → `Featherwork: Badminton Drills`**, plus descriptions and `store-assets/` screenshots/feature graphic/promo video (kept out of the listing until production on purpose).

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,11 +1,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
-  <uses-permission android:name="com.android.vending.BILLING"/>
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
   <uses-permission android:name="android.permission.RECORD_AUDIO"/>
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
   <uses-permission android:name="android.permission.VIBRATE"/>
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+  <uses-permission android:name="com.android.vending.BILLING"/>
   <queries>
     <intent>
       <action android:name="android.intent.action.VIEW"/>
@@ -14,9 +14,12 @@
     </intent>
   </queries>
   <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="true" android:theme="@style/AppTheme" android:supportsRtl="true">
-    <meta-data android:name="expo.modules.updates.ENABLED" android:value="false"/>
+    <meta-data android:name="expo.modules.updates.ENABLED" android:value="true"/>
+    <meta-data android:name="expo.modules.updates.EXPO_RUNTIME_VERSION" android:value="@string/expo_runtime_version"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH" android:value="ALWAYS"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS" android:value="0"/>
+    <meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="https://u.expo.dev/3107f01f-e992-46de-8474-423ef400912f"/>
+    <meta-data android:name="expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY" android:value="{&quot;expo-channel-name&quot;:&quot;production&quot;}"/>
     <activity android:name=".MainActivity" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|screenLayout|uiMode" android:launchMode="singleTask" android:windowSoftInputMode="adjustPan" android:theme="@style/Theme.App.SplashScreen" android:exported="true" android:screenOrientation="portrait">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -3,4 +3,5 @@
   <string name="expo_splash_screen_resize_mode" translatable="false">contain</string>
   <string name="expo_splash_screen_status_bar_translucent" translatable="false">false</string>
   <string name="expo_system_ui_user_interface_style" translatable="false">light</string>
+  <string name="expo_runtime_version">1.0.0</string>
 </resources>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         minSdkVersion = Integer.parseInt(findProperty('android.minSdkVersion') ?: '24')
         compileSdkVersion = Integer.parseInt(findProperty('android.compileSdkVersion') ?: '35')
         targetSdkVersion = Integer.parseInt(findProperty('android.targetSdkVersion') ?: '35')
-        kotlinVersion = findProperty('android.kotlinVersion') ?: '1.9.25'
+        kotlinVersion = findProperty('android.kotlinVersion') ?: '2.0.21'
 
         ndkVersion = "28.0.13004108"
     }

--- a/app.json
+++ b/app.json
@@ -2,6 +2,7 @@
   "expo": {
     "name": "Featherwork",
     "slug": "badminton-court-simulator",
+    "owner": "haritabh1992",
     "version": "2.8.1",
     "scheme": "badminton-court-simulator",
     "orientation": "portrait",
@@ -15,6 +16,13 @@
     "assetBundlePatterns": [
       "**/*"
     ],
+    "runtimeVersion": "1.0.0",
+    "updates": {
+      "url": "https://u.expo.dev/3107f01f-e992-46de-8474-423ef400912f",
+      "requestHeaders": {
+        "expo-channel-name": "production"
+      }
+    },
     "android": {
       "softwareKeyboardLayoutMode": "pan",
       "adaptiveIcon": {
@@ -46,6 +54,11 @@
     },
     "web": {
       "favicon": "./assets/logo.png"
+    },
+    "extra": {
+      "eas": {
+        "projectId": "3107f01f-e992-46de-8474-423ef400912f"
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "expo-status-bar": "~2.2.3",
         "expo-store-review": "~8.1.5",
         "expo-system-ui": "~5.0.11",
+        "expo-updates": "~0.28.18",
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "react-native": "^0.79.6",
@@ -7260,6 +7261,12 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-eas-client": {
+      "version": "0.14.4",
+      "resolved": "https://registry.npmjs.org/expo-eas-client/-/expo-eas-client-0.14.4.tgz",
+      "integrity": "sha512-TSL1BbBFIuXchJmPgbPnB7cGpOOuSGJcQ/L7gij/+zPjExwvKm5ckA5dlSulwoFhH8zQt4vb7bfISPSAWQVWBw==",
+      "license": "MIT"
+    },
     "node_modules/expo-file-system": {
       "version": "18.1.11",
       "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-18.1.11.tgz",
@@ -7317,6 +7324,12 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-json-utils": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/expo-json-utils/-/expo-json-utils-0.15.0.tgz",
+      "integrity": "sha512-duRT6oGl80IDzH2LD2yEFWNwGIC2WkozsB6HF3cDYNoNNdUvFk6uN3YiwsTsqVM/D0z6LEAQ01/SlYvN+Fw0JQ==",
+      "license": "MIT"
+    },
     "node_modules/expo-keep-awake": {
       "version": "14.1.4",
       "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-14.1.4.tgz",
@@ -7351,6 +7364,19 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-manifests": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-0.16.6.tgz",
+      "integrity": "sha512-1A+do6/mLUWF9xd3uCrlXr9QFDbjbfqAYmUy8UDLOjof1lMrOhyeC4Yi6WexA/A8dhZEpIxSMCKfn7G4aHAh4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~11.0.12",
+        "expo-json-utils": "~0.15.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {
@@ -7484,6 +7510,12 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-structured-headers": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/expo-structured-headers/-/expo-structured-headers-4.1.0.tgz",
+      "integrity": "sha512-2X+aUNzC/qaw7/WyUhrVHNDB0uQ5rE12XA2H/rJXaAiYQSuOeU90ladaN0IJYV9I2XlhYrjXLktLXWbO7zgbag==",
+      "license": "MIT"
+    },
     "node_modules/expo-system-ui": {
       "version": "5.0.11",
       "resolved": "https://registry.npmjs.org/expo-system-ui/-/expo-system-ui-5.0.11.tgz",
@@ -7503,6 +7535,49 @@
           "optional": true
         }
       }
+    },
+    "node_modules/expo-updates": {
+      "version": "0.28.18",
+      "resolved": "https://registry.npmjs.org/expo-updates/-/expo-updates-0.28.18.tgz",
+      "integrity": "sha512-qbxRF8w/xPNiEWmZHDxK4XJ0ns4A9VpQg66jNeAEc8mrX9f7TG3TyLyLtydAP0F4aTNrBcSxah8K5VA90vcPig==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/code-signing-certificates": "^0.0.6",
+        "@expo/config": "~11.0.13",
+        "@expo/config-plugins": "~10.1.2",
+        "@expo/spawn-async": "^1.7.2",
+        "arg": "4.1.0",
+        "chalk": "^4.1.2",
+        "expo-eas-client": "~0.14.4",
+        "expo-manifests": "~0.16.6",
+        "expo-structured-headers": "~4.1.0",
+        "expo-updates-interface": "~1.1.0",
+        "glob": "^10.4.2",
+        "ignore": "^5.3.1",
+        "resolve-from": "^5.0.0"
+      },
+      "bin": {
+        "expo-updates": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*"
+      }
+    },
+    "node_modules/expo-updates-interface": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-1.1.0.tgz",
+      "integrity": "sha512-DeB+fRe0hUDPZhpJ4X4bFMAItatFBUPjw/TVSbJsaf3Exeami+2qbbJhWkcTMoYHOB73nOIcaYcWXYJnCJXO0w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-updates/node_modules/arg": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
+      "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==",
+      "license": "MIT"
     },
     "node_modules/exponential-backoff": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "expo-status-bar": "~2.2.3",
     "expo-store-review": "~8.1.5",
     "expo-system-ui": "~5.0.11",
+    "expo-updates": "~0.28.18",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-native": "^0.79.6",


### PR DESCRIPTION
Adds over-the-air JS updates so monthly content drops (drills, mascots, court themes — all JS) ship without a Play release.

## What's wired
- `expo-updates@0.28.18` (SDK 53 line); lockfile diff reviewed — no react drift, no expo packages nested off the root
- EAS project `@haritabh1992/badminton-court-simulator` with `updates.url` + project ID in app.json; channel `production` → branch `production` created on EAS
- Channel baked into builds via `updates.requestHeaders` (required for gradle-built binaries)
- AndroidManifest/strings.xml synced via prebuild: updates enabled, check on launch, apply on next launch
- AGENTS.md → Releases documents the publish workflow

## Runtime version discipline
`expo.runtimeVersion` is a manually pinned string (`"1.0.0"`) — `eas update` rejects version policies with a checked-in `android/` dir. Bump it in any release that changes native code; leave it for JS-only releases so one publish reaches every compatible store build.

## Activation
No live build can receive updates yet (2.8.0/vc18 shipped with updates disabled). The next tag release (2.8.1/vc19, already bumped on main) ships the update client. After that, a content drop is just:

```
npx eas-cli update --branch production --message "July drills"
```

Publish pipeline already verified end to end against a throwaway EAS branch (accepted for runtime 1.0.0, branch deleted after).